### PR TITLE
READMEのインストール実施手順をリンク参照に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 
 ## インストール実施手順
 
-本リポジトリをローカルにダウンロードし、ルートディレクトリで以下のコマンドを実行してください。引数には、省力化コンポーネントをインストールしたいプロジェクトの絶対パスを指定してください。
+以下サイトを参照してください。
 
-    installer-cli\installer-for-next.bat ＜プロジェクトのルートディレクトリの絶対パス＞
+https://fintan-contents.github.io/spa-view-item-document/docs/introduction-guide/introduction-tool


### PR DESCRIPTION
**元Issueへのリンク**
* https://github.com/Fintan-contents/spa-view-item-component/issues/2

**リンク参照に変更した背景**
ReadMeに記載されている手順が足りない。（下記の1.）
本来の手順は、
1. npm ci コマンドを実行
2. installer-cli\installer-for-next.bat コマンドを実行

そのため、説明が散在しないように、ドキュメントの参照とする。
