### PR TITLE
【部品作成】ラベルを単体で表示するためのXxxLabelWithTagコンポーネント

### DIFF
--- a/src/framework/components/antd/AxCtrl.tsx
+++ b/src/framework/components/antd/AxCtrl.tsx
@@ -58,6 +58,21 @@ export const AxLabel = (props: AxLabelProp) => {
   );
 };
 
+export interface AxLabelWithTagProps extends AxLabelProp {
+  required: boolean;
+  showRequiredTag?: "both" | "required" | "optional" | "none";
+}
+
+export const AxLabelWithTag = (props: AxLabelWithTagProps) => {
+  const showTag = props.showRequiredTag ?? "both";
+  return (
+    <AxLabel
+      label={getLabelWithTag(props.label, props.required, showTag)}
+      color={props.color}
+    />
+  );
+};
+
 export const getClassName = <T,>(
   props: AxProps<CsItem<T>>,
   add?: string[],
@@ -83,8 +98,17 @@ export const getLabel = <T,>(
   item: CsItem<T>,
   showRequiredTag?: "both" | "required" | "optional" | "none",
 ): ReactNode => {
+  const label = item.label;
   const required = item.validationRule?.required ?? false;
   const showTag = showRequiredTag ?? (item.parentView ? "both" : "none");
+  return getLabelWithTag(label, required, showTag);
+};
+
+export const getLabelWithTag = (
+  label: string | ReactNode,
+  required: boolean,
+  showTag: "both" | "required" | "optional" | "none",
+): ReactNode => {
   const requiredTag = () => {
     switch (showTag) {
       case "both":
@@ -101,7 +125,7 @@ export const getLabel = <T,>(
   };
   return (
     <span>
-      {item.label}
+      {label}
       {requiredTag()}
     </span>
   );

--- a/src/framework/components/bootstrap/BSxCtrl.tsx
+++ b/src/framework/components/bootstrap/BSxCtrl.tsx
@@ -47,6 +47,21 @@ export const BSxLabel = (props: BSxLabelProp) => {
   );
 };
 
+export interface BSxLabelWithTagProps extends BSxLabelProp {
+  required: boolean;
+  showRequiredTag?: "both" | "required" | "optional" | "none";
+}
+
+export const BSxLabelWithTag = (props: BSxLabelWithTagProps) => {
+  const showTag = props.showRequiredTag ?? "both";
+  return (
+    <BSxLabel
+      label={getLabelWithTag(props.label, props.required, showTag)}
+      color={props.color}
+    />
+  );
+};
+
 export const getClassName = <T,>(
   props: BSxProps<CsItem<T>>,
   add?: string,
@@ -72,8 +87,17 @@ export const getLabel = <T,>(
   item: CsItem<T>,
   showRequiredTag?: "both" | "required" | "optional" | "none",
 ): ReactNode => {
+  const label = item.label;
   const required = item.validationRule?.required ?? false;
   const showTag = showRequiredTag ?? (item.parentView ? "both" : "none");
+  return getLabelWithTag(label, required, showTag);
+};
+
+export const getLabelWithTag = (
+  label: string | ReactNode,
+  required: boolean,
+  showTag: "both" | "required" | "optional" | "none",
+): ReactNode => {
   const requiredTag = () => {
     switch (showTag) {
       case "both":
@@ -102,7 +126,7 @@ export const getLabel = <T,>(
   };
   return (
     <span>
-      {item.label}
+      {label}
       {requiredTag()}
     </span>
   );

--- a/src/framework/components/mui/MxCtrl.tsx
+++ b/src/framework/components/mui/MxCtrl.tsx
@@ -58,6 +58,21 @@ export const MxLabel = (props: MxLabelProp) => {
   );
 };
 
+export interface MxLabelWithTagProps extends MxLabelProp {
+  required: boolean;
+  showRequiredTag?: "both" | "required" | "optional" | "none";
+}
+
+export const MxLabelWithTag = (props: MxLabelWithTagProps) => {
+  const showTag = props.showRequiredTag ?? "both";
+  return (
+    <MxLabel
+      label={getLabelWithTag(props.label, props.required, showTag)}
+      color={props.color}
+    />
+  );
+};
+
 export const getClassName = <T,>(
   props: MxProps<CsItem<T>>,
   add?: string,
@@ -83,8 +98,17 @@ export const getLabel = <T,>(
   item: CsItem<T>,
   showRequiredTag?: "both" | "required" | "optional" | "none",
 ): ReactNode => {
+  const label = item.label;
   const required = item.validationRule?.required ?? false;
   const showTag = showRequiredTag ?? (item.parentView ? "both" : "none");
+  return getLabelWithTag(label, required, showTag);
+};
+
+export const getLabelWithTag = (
+  label: string | ReactNode,
+  required: boolean,
+  showTag: "both" | "required" | "optional" | "none",
+): ReactNode => {
   const requiredTag = () => {
     switch (showTag) {
       case "both":
@@ -121,7 +145,7 @@ export const getLabel = <T,>(
   };
   return (
     <span>
-      {item.label}
+      {label}
       {requiredTag()}
     </span>
   );

--- a/src/framework/stories/antd/AxLabelWithTag.stories.tsx
+++ b/src/framework/stories/antd/AxLabelWithTag.stories.tsx
@@ -1,0 +1,59 @@
+import {
+  AxLabelWithTag,
+  AxLabelWithTagProps,
+} from "@/framework/components/antd";
+import { Meta, StoryObj } from "@storybook/react";
+
+/**
+ * タグ付きのラベルを単体で表示するためのコンポーネントです。
+ */
+const meta: Meta<typeof AxLabelWithTag> = {
+  title: "ant Design/AxLabelWithTag",
+  component: AxLabelWithTag,
+  tags: ["autodocs"],
+  argTypes: {
+    label: {
+      control: "text",
+      description: `ラベル名を指定します。`,
+      table: {
+        type: { summary: "string | ReactNode" },
+      },
+    },
+    required: {
+      control: "boolean",
+      description:
+        "必須タグ/任意タグのどちらを表示するかを指定します。`true`の場合は必須タグ、`false`の場合は任意タグが表示されます。",
+    },
+    showRequiredTag: {
+      control: "radio",
+      description:
+        "必須タグ/任意タグの表示有無を指定します。`required`の場合は必須タグのみ、" +
+        "`optional`の場合は任意タグのみ表示されます。`both`の場合は必須と任意両方のタグが表示されます。" +
+        "`none`の場合はタグが表示されません。<br>" +
+        "必須か任意かは、`required`propsの値が`true`であるかに依存します。",
+      table: {
+        defaultValue: { summary: "both" },
+      },
+    },
+    color: {
+      control: "color",
+      description: `ラベルの文字色を指定します。`,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const defaultArgs: Partial<AxLabelWithTagProps> = {
+  label: "ラベル",
+  required: true,
+  showRequiredTag: "both",
+};
+
+export const AxLabelWithTagStory: Story = {
+  args: defaultArgs,
+  render: function Render(args: AxLabelWithTagProps) {
+    return <AxLabelWithTag {...args} />;
+  },
+};

--- a/src/framework/stories/bootstrap/BSxLabelWithTag.stories.tsx
+++ b/src/framework/stories/bootstrap/BSxLabelWithTag.stories.tsx
@@ -1,0 +1,59 @@
+import {
+  BSxLabelWithTag,
+  BSxLabelWithTagProps,
+} from "@/framework/components/bootstrap";
+import { Meta, StoryObj } from "@storybook/react";
+
+/**
+ * タグ付きのラベルを単体で表示するためのコンポーネントです。
+ */
+const meta: Meta<typeof BSxLabelWithTag> = {
+  title: "Bootstrap/BSxLabelWithTag",
+  component: BSxLabelWithTag,
+  tags: ["autodocs"],
+  argTypes: {
+    label: {
+      control: "text",
+      description: `ラベル名を指定します。`,
+      table: {
+        type: { summary: "string | ReactNode" },
+      },
+    },
+    required: {
+      control: "boolean",
+      description:
+        "必須タグ/任意タグのどちらを表示するかを指定します。`true`の場合は必須タグ、`false`の場合は任意タグが表示されます。",
+    },
+    showRequiredTag: {
+      control: "radio",
+      description:
+        "必須タグ/任意タグの表示有無を指定します。`required`の場合は必須タグのみ、" +
+        "`optional`の場合は任意タグのみ表示されます。`both`の場合は必須と任意両方のタグが表示されます。" +
+        "`none`の場合はタグが表示されません。<br>" +
+        "必須か任意かは、`required`propsの値が`true`であるかに依存します。",
+      table: {
+        defaultValue: { summary: "both" },
+      },
+    },
+    color: {
+      control: "color",
+      description: `ラベルの文字色を指定します。`,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const defaultArgs: Partial<BSxLabelWithTagProps> = {
+  label: "ラベル",
+  required: true,
+  showRequiredTag: "both",
+};
+
+export const BSxLabelWithTagStory: Story = {
+  args: defaultArgs,
+  render: function Render(args: BSxLabelWithTagProps) {
+    return <BSxLabelWithTag {...args} />;
+  },
+};

--- a/src/framework/stories/mui/MxLabelWithTag.stories.tsx
+++ b/src/framework/stories/mui/MxLabelWithTag.stories.tsx
@@ -1,0 +1,59 @@
+import {
+  MxLabelWithTag,
+  MxLabelWithTagProps,
+} from "@/framework/components/mui";
+import { Meta, StoryObj } from "@storybook/react";
+
+/**
+ * タグ付きのラベルを単体で表示するためのコンポーネントです。
+ */
+const meta: Meta<typeof MxLabelWithTag> = {
+  title: "Material UI/MxLabelWithTag",
+  component: MxLabelWithTag,
+  tags: ["autodocs"],
+  argTypes: {
+    label: {
+      control: "text",
+      description: `ラベル名を指定します。`,
+      table: {
+        type: { summary: "string | ReactNode" },
+      },
+    },
+    required: {
+      control: "boolean",
+      description:
+        "必須タグ/任意タグのどちらを表示するかを指定します。`true`の場合は必須タグ、`false`の場合は任意タグが表示されます。",
+    },
+    showRequiredTag: {
+      control: "radio",
+      description:
+        "必須タグ/任意タグの表示有無を指定します。`required`の場合は必須タグのみ、" +
+        "`optional`の場合は任意タグのみ表示されます。`both`の場合は必須と任意両方のタグが表示されます。" +
+        "`none`の場合はタグが表示されません。<br>" +
+        "必須か任意かは、`required`propsの値が`true`であるかに依存します。",
+      table: {
+        defaultValue: { summary: "both" },
+      },
+    },
+    color: {
+      control: "color",
+      description: `ラベルの文字色を指定します。`,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const defaultArgs: Partial<MxLabelWithTagProps> = {
+  label: "ラベル",
+  required: true,
+  showRequiredTag: "both",
+};
+
+export const MxLabelWithTagStory: Story = {
+  args: defaultArgs,
+  render: function Render(args: MxLabelWithTagProps) {
+    return <MxLabelWithTag {...args} />;
+  },
+};


### PR DESCRIPTION
## 概要
ラベルを単体で表示するためのXxxLabelWithTagコンポーネントおよびStorybookを作成しました。

## 目的
- ラベルとフォームが1対多の場合、ラベルを単体で配置する必要がある
![image](https://github.com/user-attachments/assets/fa2af531-6fa1-4853-bc6d-61422cdbf539)


## 作業内容
- XxxCtrl.tsxに部品およびメソッドを追加
- Storybookを作成（以下Storybookの画面）
![image](https://github.com/user-attachments/assets/2c08b6b5-1e8a-4b44-81b1-2a8df6a89942)

## 申し送り事項
- 無し