### PR TITLE
【ライブラリ修正】文字数精査メッセージの修正

### DIFF
--- a/src/framework/logics/yup/CsYupValidationEvent.ts
+++ b/src/framework/logics/yup/CsYupValidationEvent.ts
@@ -96,7 +96,7 @@ const createStringConstraint = (
             : item.label +
               "が短すぎます。 " +
               sRule.min +
-              "文字より長い文字列を入力してください";
+              "文字以上の文字列を入力してください";
         sy = sy.min(min, message);
       }
       if (sRule.max !== undefined) {
@@ -105,7 +105,7 @@ const createStringConstraint = (
           item.label +
             "が長すぎます。 " +
             sRule.max +
-            "文字より短い文字列を入力してください",
+            "文字以下の文字列を入力してください",
         );
       }
     }
@@ -144,7 +144,7 @@ const createNumberConstraint = (
           item.label +
             "が小さすぎます。 " +
             nRule.min +
-            "より大きい数を入力してください",
+            "以上の数を入力してください",
         );
       }
       if (nRule.max !== undefined) {
@@ -153,7 +153,7 @@ const createNumberConstraint = (
           item.label +
             "が大きすぎます。 " +
             nRule.max +
-            "より小さい数を入力してください",
+            "以下の数を入力してください",
         );
       }
     }
@@ -204,7 +204,7 @@ const createNumberArrayConstraint = (
           item.label +
             "が小さすぎます。 " +
             nRule.min +
-            "より大きい数を入力してください",
+            "以上の数を入力してください",
         );
       }
       if (nRule.max) {
@@ -213,7 +213,7 @@ const createNumberArrayConstraint = (
           item.label +
             "が大きすぎます。 " +
             nRule.max +
-            "より小さい数を入力してください",
+            "以下の数を入力してください",
         );
       }
     }

--- a/src/framework/logics/yup/CsYupValidationEvent.ts
+++ b/src/framework/logics/yup/CsYupValidationEvent.ts
@@ -85,24 +85,29 @@ const createStringConstraint = (
       ? yup.string().required(item.label + "は必須です。値を設定してください")
       : yup.string().optional();
     const min = sRule.min ?? (sRule.required ? 1 : undefined);
-    if (min !== undefined) {
-      const message =
-        min === 1 && sRule.required
-          ? item.label + "は必須です。値を設定してください"
-          : item.label +
-            "が短すぎます。 " +
-            sRule.min +
-            "文字より長い文字列を入力してください";
-      sy = sy.min(min, message);
-    }
-    if (sRule.max !== undefined) {
-      sy = sy.max(
-        sRule.max,
-        item.label +
-          "が長すぎます。 " +
-          sRule.max +
-          "文字より短い文字列を入力してください",
-      );
+    if (!!min && min === sRule.max) {
+      sy = sy.min(min, item.label + "は" + min + "文字で入力してください");
+      sy = sy.max(min, item.label + "は" + min + "文字で入力してください");
+    } else {
+      if (min !== undefined) {
+        const message =
+          min === 1 && sRule.required
+            ? item.label + "は必須です。値を設定してください"
+            : item.label +
+              "が短すぎます。 " +
+              sRule.min +
+              "文字より長い文字列を入力してください";
+        sy = sy.min(min, message);
+      }
+      if (sRule.max !== undefined) {
+        sy = sy.max(
+          sRule.max,
+          item.label +
+            "が長すぎます。 " +
+            sRule.max +
+            "文字より短い文字列を入力してください",
+        );
+      }
     }
     if (sRule.email) {
       sy = sy.email(
@@ -123,23 +128,34 @@ const createNumberConstraint = (
     let ny = nRule.required
       ? yup.number().required(item.label + "は必須です。値を設定してください")
       : yup.number().optional();
-    if (nRule.min !== undefined) {
+    if (!!nRule.min && nRule.min === nRule.max) {
       ny = ny.min(
         nRule.min,
-        item.label +
-          "が小さすぎます。 " +
-          nRule.min +
-          "より大きい数を入力してください",
+        item.label + "には" + nRule.min + "を入力してください",
       );
-    }
-    if (nRule.max !== undefined) {
       ny = ny.max(
-        nRule.max,
-        item.label +
-          "が大きすぎます。 " +
-          nRule.max +
-          "より小さい数を入力してください",
+        nRule.min,
+        item.label + "には" + nRule.min + "を入力してください",
       );
+    } else {
+      if (nRule.min !== undefined) {
+        ny = ny.min(
+          nRule.min,
+          item.label +
+            "が小さすぎます。 " +
+            nRule.min +
+            "より大きい数を入力してください",
+        );
+      }
+      if (nRule.max !== undefined) {
+        ny = ny.max(
+          nRule.max,
+          item.label +
+            "が大きすぎます。 " +
+            nRule.max +
+            "より小さい数を入力してください",
+        );
+      }
     }
     validationMap.set(key, ny);
   }
@@ -172,23 +188,34 @@ const createNumberArrayConstraint = (
     let ny = nRule.required
       ? yup.number().required(item.label + "は必須です。値を設定してください")
       : yup.number().optional();
-    if (nRule.min) {
+    if (!!nRule.min && nRule.min === nRule.max) {
       ny = ny.min(
         nRule.min,
-        item.label +
-          "が小さすぎます。 " +
-          nRule.min +
-          "より大きい数を入力してください",
+        item.label + "には" + nRule.min + "を入力してください",
       );
-    }
-    if (nRule.max) {
       ny = ny.max(
-        nRule.max,
-        item.label +
-          "が大きすぎます。 " +
-          nRule.max +
-          "より小さい数を入力してください",
+        nRule.min,
+        item.label + "には" + nRule.min + "を入力してください",
       );
+    } else {
+      if (nRule.min) {
+        ny = ny.min(
+          nRule.min,
+          item.label +
+            "が小さすぎます。 " +
+            nRule.min +
+            "より大きい数を入力してください",
+        );
+      }
+      if (nRule.max) {
+        ny = ny.max(
+          nRule.max,
+          item.label +
+            "が大きすぎます。 " +
+            nRule.max +
+            "より小さい数を入力してください",
+        );
+      }
     }
     const nay = yup.array(ny);
     validationMap.set(key, nay);

--- a/src/framework/logics/zod/CsZodValidationEvent.ts
+++ b/src/framework/logics/zod/CsZodValidationEvent.ts
@@ -90,24 +90,29 @@ const createStringConstraint = (
         })
       : z.string();
     const min = sRule.min ?? (sRule.required ? 1 : undefined);
-    if (min !== undefined) {
-      const message =
-        min === 1 && sRule.required
-          ? item.label + "は必須です。値を設定してください"
-          : item.label +
-            "が短すぎます。 " +
-            sRule.min +
-            "文字より長い文字列を入力してください";
-      sz = sz.min(min, message);
-    }
-    if (sRule.max !== undefined) {
-      sz = sz.max(
-        sRule.max,
-        item.label +
-          "が長すぎます。 " +
-          sRule.max +
-          "文字より短い文字列を入力してください",
-      );
+    if (!!min && min === sRule.max) {
+      sz = sz.min(min, item.label + "は" + min + "文字で入力してください");
+      sz = sz.max(min, item.label + "は" + min + "文字で入力してください");
+    } else {
+      if (min !== undefined) {
+        const message =
+          min === 1 && sRule.required
+            ? item.label + "は必須です。値を設定してください"
+            : item.label +
+              "が短すぎます。 " +
+              sRule.min +
+              "文字より長い文字列を入力してください";
+        sz = sz.min(min, message);
+      }
+      if (sRule.max !== undefined) {
+        sz = sz.max(
+          sRule.max,
+          item.label +
+            "が長すぎます。 " +
+            sRule.max +
+            "文字より短い文字列を入力してください",
+        );
+      }
     }
     if (sRule.email) {
       sz = sz.email(
@@ -134,23 +139,34 @@ const createNumberConstraint = (
           required_error: item.label + "は必須です。値を設定してください",
         })
       : z.number();
-    if (nRule.min !== undefined) {
+    if (!!nRule.min && nRule.min === nRule.max) {
       nz = nz.min(
         nRule.min,
-        item.label +
-          "が小さすぎます。 " +
-          nRule.min +
-          "より大きい数を入力してください",
+        item.label + "には" + nRule.min + "を入力してください",
       );
-    }
-    if (nRule.max !== undefined) {
       nz = nz.max(
-        nRule.max,
-        item.label +
-          "が大きすぎます。 " +
-          nRule.max +
-          "より小さい数を入力してください",
+        nRule.min,
+        item.label + "には" + nRule.min + "を入力してください",
       );
+    } else {
+      if (nRule.min !== undefined) {
+        nz = nz.min(
+          nRule.min,
+          item.label +
+            "が小さすぎます。 " +
+            nRule.min +
+            "より大きい数を入力してください",
+        );
+      }
+      if (nRule.max !== undefined) {
+        nz = nz.max(
+          nRule.max,
+          item.label +
+            "が大きすぎます。 " +
+            nRule.max +
+            "より小さい数を入力してください",
+        );
+      }
     }
     let onz;
     if (!nRule.required) {
@@ -188,22 +204,33 @@ const createNumberArrayConstraint = (
           required_error: item.label + "は必須です。値を設定してください",
         })
       : z.number();
-    if (nRule.min)
+    if (!!nRule.min && nRule.min === nRule.max) {
       nz = nz.min(
         nRule.min,
-        item.label +
-          "が小さすぎます。 " +
-          nRule.min +
-          "より大きい数を入力してください",
+        item.label + "には" + nRule.min + "を入力してください",
       );
-    if (nRule.max)
       nz = nz.max(
-        nRule.max,
-        item.label +
-          "が大きすぎます。 " +
-          nRule.max +
-          "より小さい数を入力してください",
+        nRule.min,
+        item.label + "には" + nRule.min + "を入力してください",
       );
+    } else {
+      if (nRule.min)
+        nz = nz.min(
+          nRule.min,
+          item.label +
+            "が小さすぎます。 " +
+            nRule.min +
+            "より大きい数を入力してください",
+        );
+      if (nRule.max)
+        nz = nz.max(
+          nRule.max,
+          item.label +
+            "が大きすぎます。 " +
+            nRule.max +
+            "より小さい数を入力してください",
+        );
+    }
     let onz;
     if (!nRule.required) onz = nz.optional();
     const naz = z.array(onz ?? nz);

--- a/src/framework/logics/zod/CsZodValidationEvent.ts
+++ b/src/framework/logics/zod/CsZodValidationEvent.ts
@@ -101,7 +101,7 @@ const createStringConstraint = (
             : item.label +
               "が短すぎます。 " +
               sRule.min +
-              "文字より長い文字列を入力してください";
+              "文字以上の文字列を入力してください";
         sz = sz.min(min, message);
       }
       if (sRule.max !== undefined) {
@@ -110,7 +110,7 @@ const createStringConstraint = (
           item.label +
             "が長すぎます。 " +
             sRule.max +
-            "文字より短い文字列を入力してください",
+            "文字以下の文字列を入力してください",
         );
       }
     }
@@ -155,7 +155,7 @@ const createNumberConstraint = (
           item.label +
             "が小さすぎます。 " +
             nRule.min +
-            "より大きい数を入力してください",
+            "以上の数を入力してください",
         );
       }
       if (nRule.max !== undefined) {
@@ -164,7 +164,7 @@ const createNumberConstraint = (
           item.label +
             "が大きすぎます。 " +
             nRule.max +
-            "より小さい数を入力してください",
+            "以下の数を入力してください",
         );
       }
     }
@@ -220,7 +220,7 @@ const createNumberArrayConstraint = (
           item.label +
             "が小さすぎます。 " +
             nRule.min +
-            "より大きい数を入力してください",
+            "以上の数を入力してください",
         );
       if (nRule.max)
         nz = nz.max(
@@ -228,7 +228,7 @@ const createNumberArrayConstraint = (
           item.label +
             "が大きすぎます。 " +
             nRule.max +
-            "より小さい数を入力してください",
+            "以下の数を入力してください",
         );
     }
     let onz;


### PR DESCRIPTION
## 概要
文字数精査メッセージに関する以下の修正を行いました。
- 固定文字数の場合のエラーメッセージを修正
・文字列：{ラベル名}は{min}文字で入力してください
・数値：{ラベル名}には{min}を入力してください
- 「Xより～」という表現はXを含まないため、Xを含む表現に修正
・「Xより大きい」→「X以上の」に修正
・「Xより小さい」→「X以下の」に修正

## 申し送り事項
固定文字数の修正差分が複雑（変更が多いよう）に見えますが、修正内容はminとmaxの精査の前に
```
if (!!min && min === sRule.max) {
    sy = sy.min(min, item.label + "は" + min + "文字で入力してください");
    sy = sy.max(min, item.label + "は" + min + "文字で入力してください");
} else {
   // 既存のminとmaxの精査
   // ...
}
``` 
を追加しているのみです。（minが存在し、かつminとmaxが同じであれば、固定文字数用の精査メッセージを返す）