### PR TITLE
【ライブラリ修正】onChange, onBlurをカスタム利用可能にする

### DIFF
--- a/src/framework/components/antd/AxCtrl.tsx
+++ b/src/framework/components/antd/AxCtrl.tsx
@@ -181,23 +181,22 @@ export const AxInputText = (props: AxInputTextProps) => {
           placeholder={item.placeholder}
           {...antdProps}
           onChange={(e) => {
-            if (antdProps?.onChange) {
-              antdProps.onChange(e);
-            }
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
+            if (antdProps?.onChange) {
+              antdProps.onChange(e);
+            }
           }}
           onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
             if (antdProps?.onBlur) {
               antdProps.onBlur(e);
-            }
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
             }
           }}
         />
@@ -223,25 +222,24 @@ export const AxInputNumber = (props: AxInputNumberProps) => {
           placeholder={item.placeholder}
           {...antdProps}
           onChange={(value: ValueType | null) => {
-            if (antdProps?.onChange) {
-              antdProps.onChange(value);
-            }
             if (value !== null) {
               item.setValue(Number(value));
               if (!item.validateWhenErrorExists(Number(value))) {
                 setRefresh(true);
               }
             }
+            if (antdProps?.onChange) {
+              antdProps.onChange(value);
+            }
           }}
           onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
             if (antdProps?.onBlur) {
               antdProps.onBlur(e);
-            }
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
             }
           }}
         />
@@ -267,23 +265,22 @@ export const AxInputPassword = (props: AxInputPasswordProps) => {
           placeholder={item.placeholder}
           {...antdProps}
           onChange={(e) => {
-            if (antdProps?.onChange) {
-              antdProps.onChange(e);
-            }
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
+            if (antdProps?.onChange) {
+              antdProps.onChange(e);
+            }
           }}
           onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
             if (antdProps?.onBlur) {
               antdProps.onBlur(e);
-            }
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
             }
           }}
         />
@@ -309,23 +306,22 @@ export const AxTextArea = (props: AxTextAreaProps) => {
           placeholder={item.placeholder}
           {...antdProps}
           onChange={(e: ChangeEvent<HTMLTextAreaElement>) => {
-            if (antdProps?.onChange) {
-              antdProps.onChange(e);
-            }
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
+            if (antdProps?.onChange) {
+              antdProps.onChange(e);
+            }
           }}
           onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
             if (antdProps?.onBlur) {
               antdProps.onBlur(e);
-            }
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
             }
           }}
         />
@@ -358,23 +354,22 @@ const AxSelectBoxCommon = <
           placeholder={item.placeholder}
           {...antdProps}
           onChange={(value: V) => {
-            if (antdProps?.onChange) {
-              antdProps.onChange(value, item.options);
-            }
             item.setValue(value);
             if (!item.validateWhenErrorExists(value)) {
               setRefresh(true);
             }
+            if (antdProps?.onChange) {
+              antdProps.onChange(value, item.options);
+            }
           }}
           onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
             if (antdProps?.onBlur) {
               antdProps.onBlur(e);
-            }
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
             }
           }}
         >
@@ -428,24 +423,23 @@ export const AxRadioBox = (props: AxRadioBoxProps) => {
           value={item.value}
           {...antdProps}
           onChange={(e) => {
-            if (antdProps?.onChange) {
-              antdProps.onChange(e);
-            }
             if (item.isReadonly()) return;
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
+            if (antdProps?.onChange) {
+              antdProps.onChange(e);
+            }
           }}
           onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
             if (antdProps?.onBlur) {
               antdProps.onBlur(e);
-            }
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
             }
           }}
         >
@@ -484,11 +478,11 @@ export const AxCheckBox = (props: AxCheckBoxProps) => {
           checked={item.value}
           {...antdProps}
           onChange={(e) => {
+            if (item.isReadonly()) return;
+            item.setValue(e.target.checked);
             if (antdProps?.onChange) {
               antdProps.onChange(e);
             }
-            if (item.isReadonly()) return;
-            item.setValue(e.target.checked);
           }}
         >
           {item.checkBoxText}
@@ -531,9 +525,6 @@ export const AxMultiCheckBox = (props: AxMultiCheckBoxProps) => {
                 disabled={item.isReadonly() && !item.value?.includes(value)}
                 {...antdProps}
                 onChange={(e) => {
-                  if (antdProps?.onChange) {
-                    antdProps.onChange(e);
-                  }
                   if (item.isReadonly()) return;
                   let newValue: string[];
                   if (e.target.checked) {
@@ -546,6 +537,9 @@ export const AxMultiCheckBox = (props: AxMultiCheckBoxProps) => {
                   item.setValue(newValue);
                   if (!item.validateWhenErrorExists(newValue)) {
                     setRefresh(true);
+                  }
+                  if (antdProps?.onChange) {
+                    antdProps.onChange(e);
                   }
                 }}
               >

--- a/src/framework/components/antd/AxCtrl.tsx
+++ b/src/framework/components/antd/AxCtrl.tsx
@@ -179,13 +179,20 @@ export const AxInputText = (props: AxInputTextProps) => {
           value={item.value}
           readOnly={item.isReadonly()}
           placeholder={item.placeholder}
+          {...antdProps}
           onChange={(e) => {
+            if (antdProps?.onChange) {
+              antdProps.onChange(e);
+            }
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
           }}
-          onBlur={() => {
+          onBlur={(e) => {
+            if (antdProps?.onBlur) {
+              antdProps.onBlur(e);
+            }
             if (item.parentView?.validateTrigger !== "onBlur") {
               return;
             }
@@ -193,7 +200,6 @@ export const AxInputText = (props: AxInputTextProps) => {
               setRefresh(true);
             }
           }}
-          {...antdProps}
         />
       )}
     /> // AxEditCtrl
@@ -215,7 +221,11 @@ export const AxInputNumber = (props: AxInputNumberProps) => {
           value={item.value}
           readOnly={item.isReadonly()}
           placeholder={item.placeholder}
+          {...antdProps}
           onChange={(value: ValueType | null) => {
+            if (antdProps?.onChange) {
+              antdProps.onChange(value);
+            }
             if (value !== null) {
               item.setValue(Number(value));
               if (!item.validateWhenErrorExists(Number(value))) {
@@ -223,7 +233,10 @@ export const AxInputNumber = (props: AxInputNumberProps) => {
               }
             }
           }}
-          onBlur={() => {
+          onBlur={(e) => {
+            if (antdProps?.onBlur) {
+              antdProps.onBlur(e);
+            }
             if (item.parentView?.validateTrigger !== "onBlur") {
               return;
             }
@@ -231,7 +244,6 @@ export const AxInputNumber = (props: AxInputNumberProps) => {
               setRefresh(true);
             }
           }}
-          {...antdProps}
         />
       )}
     /> // AxEditCtrl
@@ -253,13 +265,20 @@ export const AxInputPassword = (props: AxInputPasswordProps) => {
           value={item.value}
           readOnly={item.isReadonly()}
           placeholder={item.placeholder}
+          {...antdProps}
           onChange={(e) => {
+            if (antdProps?.onChange) {
+              antdProps.onChange(e);
+            }
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
           }}
-          onBlur={() => {
+          onBlur={(e) => {
+            if (antdProps?.onBlur) {
+              antdProps.onBlur(e);
+            }
             if (item.parentView?.validateTrigger !== "onBlur") {
               return;
             }
@@ -267,7 +286,6 @@ export const AxInputPassword = (props: AxInputPasswordProps) => {
               setRefresh(true);
             }
           }}
-          {...antdProps}
         />
       )}
     /> // AxEditCtrl
@@ -289,13 +307,20 @@ export const AxTextArea = (props: AxTextAreaProps) => {
           value={item.value}
           readOnly={item.isReadonly()}
           placeholder={item.placeholder}
+          {...antdProps}
           onChange={(e: ChangeEvent<HTMLTextAreaElement>) => {
+            if (antdProps?.onChange) {
+              antdProps.onChange(e);
+            }
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
           }}
-          onBlur={() => {
+          onBlur={(e) => {
+            if (antdProps?.onBlur) {
+              antdProps.onBlur(e);
+            }
             if (item.parentView?.validateTrigger !== "onBlur") {
               return;
             }
@@ -303,7 +328,6 @@ export const AxTextArea = (props: AxTextAreaProps) => {
               setRefresh(true);
             }
           }}
-          {...antdProps}
         />
       )}
     /> // AxEditCtrl
@@ -332,13 +356,20 @@ const AxSelectBoxCommon = <
           className={getClassName(props, ["fit-content"])}
           value={item.value}
           placeholder={item.placeholder}
+          {...antdProps}
           onChange={(value: V) => {
+            if (antdProps?.onChange) {
+              antdProps.onChange(value, item.options);
+            }
             item.setValue(value);
             if (!item.validateWhenErrorExists(value)) {
               setRefresh(true);
             }
           }}
-          onBlur={() => {
+          onBlur={(e) => {
+            if (antdProps?.onBlur) {
+              antdProps.onBlur(e);
+            }
             if (item.parentView?.validateTrigger !== "onBlur") {
               return;
             }
@@ -346,7 +377,6 @@ const AxSelectBoxCommon = <
               setRefresh(true);
             }
           }}
-          {...antdProps}
         >
           {item.options.map((o) => {
             return !item.isReadonly() ||
@@ -396,14 +426,21 @@ export const AxRadioBox = (props: AxRadioBoxProps) => {
         <Radio.Group
           className={getClassName(props, ["fit-content"])}
           value={item.value}
+          {...antdProps}
           onChange={(e) => {
+            if (antdProps?.onChange) {
+              antdProps.onChange(e);
+            }
             if (item.isReadonly()) return;
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
           }}
-          onBlur={() => {
+          onBlur={(e) => {
+            if (antdProps?.onBlur) {
+              antdProps.onBlur(e);
+            }
             if (item.parentView?.validateTrigger !== "onBlur") {
               return;
             }
@@ -411,7 +448,6 @@ export const AxRadioBox = (props: AxRadioBoxProps) => {
               setRefresh(true);
             }
           }}
-          {...antdProps}
         >
           {item.options.map((o) => {
             return (
@@ -446,11 +482,14 @@ export const AxCheckBox = (props: AxCheckBoxProps) => {
           className={getClassName(props, ["fit-content", "checkbox"])}
           value={item.value}
           checked={item.value}
+          {...antdProps}
           onChange={(e) => {
+            if (antdProps?.onChange) {
+              antdProps.onChange(e);
+            }
             if (item.isReadonly()) return;
             item.setValue(e.target.checked);
           }}
-          {...antdProps}
         >
           {item.checkBoxText}
         </Checkbox>
@@ -489,7 +528,12 @@ export const AxMultiCheckBox = (props: AxMultiCheckBoxProps) => {
                 key={value}
                 value={value}
                 checked={item.value?.includes(value)}
+                disabled={item.isReadonly() && !item.value?.includes(value)}
+                {...antdProps}
                 onChange={(e) => {
+                  if (antdProps?.onChange) {
+                    antdProps.onChange(e);
+                  }
                   if (item.isReadonly()) return;
                   let newValue: string[];
                   if (e.target.checked) {
@@ -504,8 +548,6 @@ export const AxMultiCheckBox = (props: AxMultiCheckBoxProps) => {
                     setRefresh(true);
                   }
                 }}
-                disabled={item.isReadonly() && !item.value?.includes(value)}
-                {...antdProps}
               >
                 {text}
               </Checkbox>

--- a/src/framework/components/antd/AxCtrlAdvanced.tsx
+++ b/src/framework/components/antd/AxCtrlAdvanced.tsx
@@ -181,9 +181,9 @@ export const AxInputNumberRange = (props: AxInputNumberRangeProps) => {
                     setRefresh(true);
                   }
                 }
-                if (antdPropsLower?.onBlur) {
-                  antdPropsLower.onBlur(e);
-                }
+              }
+              if (antdPropsLower?.onBlur) {
+                antdPropsLower.onBlur(e);
               }
             }}
           />
@@ -218,9 +218,9 @@ export const AxInputNumberRange = (props: AxInputNumberRangeProps) => {
                     setRefresh(true);
                   }
                 }
-                if (antdPropsUpper?.onBlur) {
-                  antdPropsUpper?.onBlur(e);
-                }
+              }
+              if (antdPropsUpper?.onBlur) {
+                antdPropsUpper?.onBlur(e);
               }
             }}
           />

--- a/src/framework/components/antd/AxCtrlAdvanced.tsx
+++ b/src/framework/components/antd/AxCtrlAdvanced.tsx
@@ -43,14 +43,14 @@ export const AxInputDate = (props: AxInputDateProps) => {
             format={item.displayFormat}
             {...antdProps}
             onChange={(value: Dayjs, dateString: string | string[]) => {
-              const newValue = value?.format(item.valueFormat);
-              if (antdProps?.onChange) {
-                antdProps.onChange(value, newValue);
-              }
               if (item.isReadonly()) return;
+              const newValue = value?.format(item.valueFormat);
               item.setValue(newValue);
               if (!item.validateWhenErrorExists(newValue ?? "")) {
                 setRefresh(true);
+              }
+              if (antdProps?.onChange) {
+                antdProps.onChange(value, newValue);
               }
             }}
           />
@@ -86,6 +86,9 @@ export const AxInputDateRange: React.FC<AxInputDateRangeProp> = (
           format={item.format}
           {...antdProps}
           onCalendarChange={(dates, _, __) => {
+            if (item.isReadonly()) {
+              return;
+            }
             const newFrom =
               dates && dates.length == 2
                 ? dates[0]?.format(item.getValueFormat())
@@ -95,12 +98,6 @@ export const AxInputDateRange: React.FC<AxInputDateRangeProp> = (
                 ? dates[1]?.format(item.getValueFormat())
                 : undefined;
             const newValue = [newFrom ?? "", newTo ?? ""];
-            if (antdProps?.onCalendarChange) {
-              antdProps.onCalendarChange(dates, [newValue[0], newValue[1]], __);
-            }
-            if (item.isReadonly()) {
-              return;
-            }
             item.setValue(newValue);
             if (!item.validateWhenErrorExists(newValue)) {
               setRefresh(true);
@@ -113,11 +110,11 @@ export const AxInputDateRange: React.FC<AxInputDateRangeProp> = (
             ) {
               setRefresh(true);
             }
+            if (antdProps?.onCalendarChange) {
+              antdProps.onCalendarChange(dates, [newValue[0], newValue[1]], __);
+            }
           }}
           onBlur={(e, info) => {
-            if (antdProps?.onBlur) {
-              antdProps.onBlur(e, info);
-            }
             if (item.parentView?.validateTrigger === "onBlur") {
               // Calendar の変更を伴わないフォーカスアウトが行われた場合のバリデーション
               // onCalendarChange のバリデーションと重複してしまうので、値が未入力の場合に限定する。
@@ -130,6 +127,9 @@ export const AxInputDateRange: React.FC<AxInputDateRangeProp> = (
               ) {
                 setRefresh(true);
               }
+            }
+            if (antdProps?.onBlur) {
+              antdProps.onBlur(e, info);
             }
           }}
         />
@@ -157,9 +157,6 @@ export const AxInputNumberRange = (props: AxInputNumberRangeProps) => {
             readOnly={item.isReadonly()}
             {...antdPropsLower}
             onChange={(value) => {
-              if (antdPropsLower?.onChange) {
-                antdPropsLower.onChange(value);
-              }
               const newValue = value ? value : undefined;
               item.setLowerValue(newValue as number);
               if (
@@ -170,20 +167,23 @@ export const AxInputNumberRange = (props: AxInputNumberRangeProps) => {
               ) {
                 setRefresh(true);
               }
+              if (antdPropsLower?.onChange) {
+                antdPropsLower.onChange(value);
+              }
             }}
             onBlur={(e) => {
-              if (antdPropsLower?.onBlur) {
-                antdPropsLower.onBlur(e);
-              }
-              if (!item.lowerValue) return;
-              if (item.upperValue && item.upperValue < item.lowerValue) {
-                item.setUpperValue(item.lowerValue);
-              }
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
-              }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (item.lowerValue) {
+                if (item.upperValue && item.upperValue < item.lowerValue) {
+                  item.setUpperValue(item.lowerValue);
+                }
+                if (item.parentView?.validateTrigger === "onBlur") {
+                  if (!item.validate(item.value)) {
+                    setRefresh(true);
+                  }
+                }
+                if (antdPropsLower?.onBlur) {
+                  antdPropsLower.onBlur(e);
+                }
               }
             }}
           />
@@ -194,9 +194,6 @@ export const AxInputNumberRange = (props: AxInputNumberRangeProps) => {
             readOnly={item.isReadonly()}
             {...antdPropsUpper}
             onChange={(value) => {
-              if (antdPropsUpper?.onChange) {
-                antdPropsUpper.onChange(value);
-              }
               const newValue = value ? value : undefined;
               item.setUpperValue(newValue as number);
               if (
@@ -207,20 +204,23 @@ export const AxInputNumberRange = (props: AxInputNumberRangeProps) => {
               ) {
                 setRefresh(true);
               }
+              if (antdPropsUpper?.onChange) {
+                antdPropsUpper.onChange(value);
+              }
             }}
             onBlur={(e) => {
-              if (antdPropsUpper?.onBlur) {
-                antdPropsUpper?.onBlur(e);
-              }
-              if (!item.upperValue) return;
-              if (item.lowerValue && item.lowerValue > item.upperValue) {
-                item.setLowerValue(item.upperValue);
-              }
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
-              }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (item.upperValue) {
+                if (item.lowerValue && item.lowerValue > item.upperValue) {
+                  item.setLowerValue(item.upperValue);
+                }
+                if (item.parentView?.validateTrigger === "onBlur") {
+                  if (!item.validate(item.value)) {
+                    setRefresh(true);
+                  }
+                }
+                if (antdPropsUpper?.onBlur) {
+                  antdPropsUpper?.onBlur(e);
+                }
               }
             }}
           />

--- a/src/framework/components/antd/AxCtrlAdvanced.tsx
+++ b/src/framework/components/antd/AxCtrlAdvanced.tsx
@@ -172,14 +172,17 @@ export const AxInputNumberRange = (props: AxInputNumberRangeProps) => {
               }
             }}
             onBlur={(e) => {
-              if (item.lowerValue) {
-                if (item.upperValue && item.upperValue < item.lowerValue) {
-                  item.setUpperValue(item.lowerValue);
-                }
-                if (item.parentView?.validateTrigger === "onBlur") {
-                  if (!item.validate(item.value)) {
-                    setRefresh(true);
-                  }
+              if (
+                item.lowerValue &&
+                item.upperValue &&
+                item.lowerValue > item.upperValue
+              ) {
+                // 下限値が上限値より大きい場合、上限値を下限値に合わせる
+                item.setUpperValue(item.lowerValue);
+              }
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
                 }
               }
               if (antdPropsLower?.onBlur) {
@@ -209,14 +212,17 @@ export const AxInputNumberRange = (props: AxInputNumberRangeProps) => {
               }
             }}
             onBlur={(e) => {
-              if (item.upperValue) {
-                if (item.lowerValue && item.lowerValue > item.upperValue) {
-                  item.setLowerValue(item.upperValue);
-                }
-                if (item.parentView?.validateTrigger === "onBlur") {
-                  if (!item.validate(item.value)) {
-                    setRefresh(true);
-                  }
+              if (
+                item.lowerValue &&
+                item.upperValue &&
+                item.upperValue < item.lowerValue
+              ) {
+                // 上限値が下限値より小さい場合、下限値を上限値に合わせる
+                item.setLowerValue(item.upperValue);
+              }
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
                 }
               }
               if (antdPropsUpper?.onBlur) {

--- a/src/framework/components/antd/AxCtrlAdvanced.tsx
+++ b/src/framework/components/antd/AxCtrlAdvanced.tsx
@@ -12,7 +12,7 @@ import {
   CsInputDateRangeItem,
   CsInputNumberRangeItem,
 } from "../../logics";
-import { AxProps, AxEditCtrl, getClassName } from "./AxCtrl";
+import { AxEditCtrl, AxProps, getClassName } from "./AxCtrl";
 
 const { RangePicker } = DatePicker;
 type RangePickerProps = GetProps<typeof DatePicker.RangePicker>;
@@ -41,15 +41,18 @@ export const AxInputDate = (props: AxInputDateProps) => {
             className={getClassName(props, ["fit-content"])}
             value={item.value ? dayjs(item.value) : undefined}
             format={item.displayFormat}
+            {...antdProps}
             onChange={(value: Dayjs, dateString: string | string[]) => {
-              if (item.isReadonly()) return;
               const newValue = value?.format(item.valueFormat);
+              if (antdProps?.onChange) {
+                antdProps.onChange(value, newValue);
+              }
+              if (item.isReadonly()) return;
               item.setValue(newValue);
               if (!item.validateWhenErrorExists(newValue ?? "")) {
                 setRefresh(true);
               }
             }}
-            {...antdProps}
           />
         </div>
       )}
@@ -74,10 +77,15 @@ export const AxInputDateRange: React.FC<AxInputDateRangeProp> = (
         <RangePicker
           picker={item.isYearMonth() ? "month" : undefined}
           className={getClassName(props, ["fit-content"])}
+          allowClear={!item.validationRule.required}
+          value={[from, to] as [dayjs.Dayjs, dayjs.Dayjs]}
+          placeholder={[
+            item.lowerPlaceholder ?? "開始日を選択してください",
+            item.upperPlaceholder ?? "終了日を選択してください",
+          ]}
+          format={item.format}
+          {...antdProps}
           onCalendarChange={(dates, _, __) => {
-            if (item.isReadonly()) {
-              return;
-            }
             const newFrom =
               dates && dates.length == 2
                 ? dates[0]?.format(item.getValueFormat())
@@ -87,6 +95,12 @@ export const AxInputDateRange: React.FC<AxInputDateRangeProp> = (
                 ? dates[1]?.format(item.getValueFormat())
                 : undefined;
             const newValue = [newFrom ?? "", newTo ?? ""];
+            if (antdProps?.onCalendarChange) {
+              antdProps.onCalendarChange(dates, [newValue[0], newValue[1]], __);
+            }
+            if (item.isReadonly()) {
+              return;
+            }
             item.setValue(newValue);
             if (!item.validateWhenErrorExists(newValue)) {
               setRefresh(true);
@@ -100,15 +114,10 @@ export const AxInputDateRange: React.FC<AxInputDateRangeProp> = (
               setRefresh(true);
             }
           }}
-          allowClear={!item.validationRule.required}
-          value={[from, to] as [dayjs.Dayjs, dayjs.Dayjs]}
-          placeholder={[
-            item.lowerPlaceholder ?? "開始日を選択してください",
-            item.upperPlaceholder ?? "終了日を選択してください",
-          ]}
-          format={item.format}
-          {...antdProps}
           onBlur={(e, info) => {
+            if (antdProps?.onBlur) {
+              antdProps.onBlur(e, info);
+            }
             if (item.parentView?.validateTrigger === "onBlur") {
               // Calendar の変更を伴わないフォーカスアウトが行われた場合のバリデーション
               // onCalendarChange のバリデーションと重複してしまうので、値が未入力の場合に限定する。
@@ -121,9 +130,6 @@ export const AxInputDateRange: React.FC<AxInputDateRangeProp> = (
               ) {
                 setRefresh(true);
               }
-            }
-            if (antdProps?.onBlur) {
-              antdProps.onBlur(e, info);
             }
           }}
         />
@@ -149,7 +155,11 @@ export const AxInputNumberRange = (props: AxInputNumberRangeProps) => {
             className={getClassName(props, ["input-number"])}
             value={item.lowerValue}
             readOnly={item.isReadonly()}
+            {...antdPropsLower}
             onChange={(value) => {
+              if (antdPropsLower?.onChange) {
+                antdPropsLower.onChange(value);
+              }
               const newValue = value ? value : undefined;
               item.setLowerValue(newValue as number);
               if (
@@ -161,7 +171,10 @@ export const AxInputNumberRange = (props: AxInputNumberRangeProps) => {
                 setRefresh(true);
               }
             }}
-            onBlur={() => {
+            onBlur={(e) => {
+              if (antdPropsLower?.onBlur) {
+                antdPropsLower.onBlur(e);
+              }
               if (!item.lowerValue) return;
               if (item.upperValue && item.upperValue < item.lowerValue) {
                 item.setUpperValue(item.lowerValue);
@@ -173,14 +186,17 @@ export const AxInputNumberRange = (props: AxInputNumberRangeProps) => {
                 setRefresh(true);
               }
             }}
-            {...antdPropsLower}
           />
           <span> ～ </span>
           <InputNumber
             className={getClassName(props, ["input-number"])}
             value={item.upperValue}
             readOnly={item.isReadonly()}
+            {...antdPropsUpper}
             onChange={(value) => {
+              if (antdPropsUpper?.onChange) {
+                antdPropsUpper.onChange(value);
+              }
               const newValue = value ? value : undefined;
               item.setUpperValue(newValue as number);
               if (
@@ -192,7 +208,10 @@ export const AxInputNumberRange = (props: AxInputNumberRangeProps) => {
                 setRefresh(true);
               }
             }}
-            onBlur={() => {
+            onBlur={(e) => {
+              if (antdPropsUpper?.onBlur) {
+                antdPropsUpper?.onBlur(e);
+              }
               if (!item.upperValue) return;
               if (item.lowerValue && item.lowerValue > item.upperValue) {
                 item.setLowerValue(item.upperValue);
@@ -204,7 +223,6 @@ export const AxInputNumberRange = (props: AxInputNumberRangeProps) => {
                 setRefresh(true);
               }
             }}
-            {...antdPropsUpper}
           />
         </div>
       )}

--- a/src/framework/components/bootstrap/BSxCtrl.tsx
+++ b/src/framework/components/bootstrap/BSxCtrl.tsx
@@ -184,21 +184,26 @@ export const BSxInputText = (props: BSxInputTextProps) => {
           as="input"
           value={item.value}
           readOnly={item.isReadonly()}
+          {...bsProps}
           onChange={(e) => {
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (bsProps?.onChange) {
+              bsProps.onChange(e);
             }
           }}
-          {...bsProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (bsProps?.onBlur) {
+              bsProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // BSxEditCtrl
@@ -222,6 +227,7 @@ export const BSxInputNumber = (props: BSxInputNumberProps) => {
           type="number"
           value={item.value}
           readOnly={item.isReadonly()}
+          {...bsProps}
           onChange={(e) => {
             const newValue = e.target.value ? e.target.value : undefined;
             const newNumber = newValue ? Number(newValue) : undefined;
@@ -229,16 +235,20 @@ export const BSxInputNumber = (props: BSxInputNumberProps) => {
             if (!item.validateWhenErrorExists(newNumber as number)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (bsProps?.onChange) {
+              bsProps.onChange(e);
             }
           }}
-          {...bsProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (bsProps?.onBlur) {
+              bsProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // BSxEditCtrl
@@ -262,21 +272,26 @@ export const BSxInputPassword = (props: BSxInputPasswordProps) => {
           type="password"
           value={item.value}
           readOnly={item.isReadonly()}
+          {...bsProps}
           onChange={(e) => {
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (bsProps?.onChange) {
+              bsProps.onChange(e);
             }
           }}
-          {...bsProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (bsProps?.onBlur) {
+              bsProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // BSxEditCtrl
@@ -300,21 +315,26 @@ export const BSxTextArea = (props: BSxTextAreaProps) => {
           as="textarea"
           value={item.value}
           readOnly={item.isReadonly()}
+          {...bsProps}
           onChange={(e) => {
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (bsProps?.onChange) {
+              bsProps.onChange(e);
             }
           }}
-          {...bsProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (bsProps?.onBlur) {
+              bsProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // BSxEditCtrl
@@ -345,22 +365,27 @@ const BSxSelectBoxCommon = <
         <Form.Select
           className={getClassName(props, "fit-content")}
           value={item.value}
+          {...bsProps}
           onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
             const newValue = e.target.value;
             item.setValue(toValue(newValue));
             if (!item.validateWhenErrorExists(toValue(newValue) as V)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (bsProps?.onChange) {
+              bsProps.onChange(e);
             }
           }}
-          {...bsProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (bsProps?.onBlur) {
+              bsProps.onBlur(e);
+            }
+          }}
         >
           {(item.value === undefined || item.value === "") && (
             <option key="" value="" disabled={true} />
@@ -445,14 +470,17 @@ export const BSxRadioBox = (props: BSxRadioBoxProps) => {
                 value={value}
                 label={label}
                 disabled={item.isReadonly() && item.value !== value}
+                checked={item.value === value}
+                {...bsProps}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   item.setValue(e.target.value);
                   if (!item.validateWhenErrorExists(e.target.value)) {
                     setRefresh(true);
                   }
+                  if (bsProps?.onChange) {
+                    bsProps.onChange(e);
+                  }
                 }}
-                checked={item.value === value}
-                {...bsProps}
               />
             );
           })}
@@ -484,17 +512,19 @@ export const BSxCheckBox = (props: BSxCheckBoxProps) => {
               setRefresh(true);
             }
           }}
-          {...bsProps}
         >
           <Form.Check
             type="checkbox"
             label={item.checkBoxText}
             defaultChecked={item.isChecked()}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              item.setValue(e.target.checked);
-            }}
             disabled={item.isReadonly()}
             {...bsProps}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              item.setValue(e.target.checked);
+              if (bsProps?.onChange) {
+                bsProps.onChange(e);
+              }
+            }}
           />
         </Form.Group>
       )}
@@ -536,6 +566,8 @@ export const BSxMultiCheckBox = (props: BSxMultiCheckBoxProps) => {
                 type="checkbox"
                 defaultChecked={item.value?.includes(value)}
                 label={text}
+                disabled={item.isReadonly() && !item.value?.includes(value)}
+                {...bsProps}
                 onChange={(e) => {
                   if (item.isReadonly()) return;
                   let newValue: string[];
@@ -550,9 +582,10 @@ export const BSxMultiCheckBox = (props: BSxMultiCheckBoxProps) => {
                   if (!item.validateWhenErrorExists(newValue)) {
                     setRefresh(true);
                   }
+                  if (bsProps?.onChange) {
+                    bsProps.onChange(e);
+                  }
                 }}
-                disabled={item.isReadonly() && !item.value?.includes(value)}
-                {...bsProps}
               />
             );
           })}

--- a/src/framework/components/bootstrap/BSxCtrlAdvanced.tsx
+++ b/src/framework/components/bootstrap/BSxCtrlAdvanced.tsx
@@ -29,6 +29,7 @@ export const BSxInputDate = (props: BSxInputDateProps) => {
           className={getClassName(props, "fit-content")}
           type="date"
           value={displayValue}
+          {...bsProps}
           onChange={(e) => {
             if (item.isReadonly()) return;
             const newValue = e.target.value ? e.target.value : undefined;
@@ -39,16 +40,20 @@ export const BSxInputDate = (props: BSxInputDateProps) => {
             if (!item.validateWhenErrorExists(newValue)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (bsProps?.onChange) {
+              bsProps.onChange(e);
             }
           }}
-          {...bsProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (bsProps?.onBlur) {
+              bsProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // BSxEditCtrl
@@ -78,6 +83,7 @@ export const BSxInputDateRange = (props: BSxInputDateRangeProps) => {
             type="date"
             value={fromDisplayValue}
             readOnly={item.isReadonly()}
+            {...bsPropsLower}
             onChange={(e) => {
               const newValue = e.target.value ? e.target.value : undefined;
               const newDate = newValue
@@ -92,20 +98,28 @@ export const BSxInputDateRange = (props: BSxInputDateRangeProps) => {
               ) {
                 setRefresh(true);
               }
+              if (bsPropsLower?.onChange) {
+                bsPropsLower.onChange(e);
+              }
             }}
-            onBlur={() => {
-              if (!item.lowerValue) return;
-              if (item.upperValue && item.upperValue < item.lowerValue) {
+            onBlur={(e) => {
+              if (
+                item.lowerValue &&
+                item.upperValue &&
+                item.lowerValue > item.upperValue
+              ) {
+                // 下限値が上限値より大きい場合、上限値を下限値に合わせる
                 item.setUpperValue(item.lowerValue);
               }
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
+                }
               }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (bsPropsLower?.onBlur) {
+                bsPropsLower.onBlur(e);
               }
             }}
-            {...bsPropsLower}
           />
           <span
             style={{
@@ -122,6 +136,7 @@ export const BSxInputDateRange = (props: BSxInputDateRangeProps) => {
             type="date"
             value={toDisplayValue}
             readOnly={item.isReadonly()}
+            {...bsPropsUpper}
             onChange={(e) => {
               const newValue = e.target.value ? e.target.value : undefined;
               const newDate = newValue
@@ -136,20 +151,28 @@ export const BSxInputDateRange = (props: BSxInputDateRangeProps) => {
               ) {
                 setRefresh(true);
               }
+              if (bsPropsUpper?.onChange) {
+                bsPropsUpper.onChange(e);
+              }
             }}
-            onBlur={() => {
-              if (!item.upperValue) return;
-              if (item.lowerValue && item.lowerValue > item.upperValue) {
+            onBlur={(e) => {
+              if (
+                item.lowerValue &&
+                item.upperValue &&
+                item.upperValue < item.lowerValue
+              ) {
+                // 上限値が下限値より小さい場合、下限値を上限値に合わせる
                 item.setLowerValue(item.upperValue);
               }
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
+                }
               }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (bsPropsUpper?.onBlur) {
+                bsPropsUpper.onBlur(e);
               }
             }}
-            {...bsPropsUpper}
           />
         </div>
       )}
@@ -179,6 +202,7 @@ export const BSxInputNumberRange = (props: BSxInputNumberRangeProps) => {
             type="number"
             value={item.lowerValue}
             readOnly={item.isReadonly()}
+            {...bsPropsLower}
             onChange={(e) => {
               const newValue = e.target.value ? e.target.value : undefined;
               const newNumber = newValue ? Number(newValue) : undefined;
@@ -191,20 +215,28 @@ export const BSxInputNumberRange = (props: BSxInputNumberRangeProps) => {
               ) {
                 setRefresh(true);
               }
+              if (bsPropsLower?.onChange) {
+                bsPropsLower.onChange(e);
+              }
             }}
-            onBlur={() => {
-              if (!item.lowerValue) return;
-              if (item.upperValue && item.upperValue < item.lowerValue) {
+            onBlur={(e) => {
+              if (
+                item.lowerValue &&
+                item.upperValue &&
+                item.lowerValue > item.upperValue
+              ) {
+                // 下限値が上限値より大きい場合、上限値を下限値に合わせる
                 item.setUpperValue(item.lowerValue);
               }
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
+                }
               }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (bsPropsLower?.onBlur) {
+                bsPropsLower.onBlur(e);
               }
             }}
-            {...bsPropsLower}
           />
           <span
             style={{
@@ -221,6 +253,7 @@ export const BSxInputNumberRange = (props: BSxInputNumberRangeProps) => {
             type="number"
             value={item.upperValue}
             readOnly={item.isReadonly()}
+            {...bsPropsUpper}
             onChange={(e) => {
               const newValue = e.target.value ? e.target.value : undefined;
               const newNumber = newValue ? Number(newValue) : undefined;
@@ -233,20 +266,28 @@ export const BSxInputNumberRange = (props: BSxInputNumberRangeProps) => {
               ) {
                 setRefresh(true);
               }
+              if (bsPropsUpper?.onChange) {
+                bsPropsUpper.onChange(e);
+              }
             }}
-            onBlur={() => {
-              if (!item.upperValue) return;
-              if (item.lowerValue && item.lowerValue > item.upperValue) {
+            onBlur={(e) => {
+              if (
+                item.lowerValue &&
+                item.upperValue &&
+                item.upperValue < item.lowerValue
+              ) {
+                // 上限値が下限値より小さい場合、下限値を上限値に合わせる
                 item.setLowerValue(item.upperValue);
               }
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
+                }
               }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (bsPropsUpper?.onBlur) {
+                bsPropsUpper?.onBlur(e);
               }
             }}
-            {...bsPropsUpper}
           />
         </div>
       )}

--- a/src/framework/components/mui/MxCtrl.tsx
+++ b/src/framework/components/mui/MxCtrl.tsx
@@ -200,21 +200,26 @@ export const MxInputText = (props: MxInputTextProps) => {
           className={getClassName(props)}
           value={item.value}
           inputProps={{ readOnly: item.isReadonly() }}
-          onChange={(e: any) => {
+          {...muiProps}
+          onChange={(e) => {
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (muiProps?.onChange) {
+              muiProps.onChange(e);
             }
           }}
-          {...muiProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (muiProps?.onBlur) {
+              muiProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // MxEditCtrl
@@ -237,6 +242,7 @@ export const MxInputNumber = (props: MxInputNumberProps) => {
           inputProps={{
             readOnly: item.isReadonly(),
           }}
+          {...muiProps}
           onChange={(
             e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
           ) => {
@@ -250,16 +256,20 @@ export const MxInputNumber = (props: MxInputNumberProps) => {
                 setRefresh(true);
               }
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (muiProps?.onChange) {
+              muiProps.onChange(e);
             }
           }}
-          {...muiProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (muiProps?.onBlur) {
+              muiProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // MxEditCtrl
@@ -283,6 +293,7 @@ export const MxInputPassword = (props: MxInputPasswordProps) => {
             readOnly: item.isReadonly(),
           }}
           type="password"
+          {...muiProps}
           onChange={(
             e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
           ) => {
@@ -290,16 +301,20 @@ export const MxInputPassword = (props: MxInputPasswordProps) => {
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (muiProps?.onChange) {
+              muiProps.onChange(e);
             }
           }}
-          {...muiProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (muiProps?.onBlur) {
+              muiProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // MxEditCtrl
@@ -328,6 +343,7 @@ export const MxTextArea = (props: MxTextAreaProps) => {
           // multiline
           // minRows={4}
           variant="outlined"
+          {...muiProps}
           onChange={(
             e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
           ) => {
@@ -335,16 +351,20 @@ export const MxTextArea = (props: MxTextAreaProps) => {
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (muiProps?.onChange) {
+              muiProps.onChange(e);
             }
           }}
-          {...muiProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (muiProps?.onBlur) {
+              muiProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // MxEditCtrl
@@ -373,22 +393,27 @@ const MxSelectBoxCommon = <
         <Select
           className={getClassName(props, "fit-content")}
           value={item.value}
-          onChange={(e: SelectChangeEvent<V>) => {
+          {...muiProps}
+          onChange={(e: SelectChangeEvent<V>, child: React.ReactNode) => {
             const newValue = e.target.value ? e.target.value.toString() : "";
             item.setValue(toValue(newValue));
             if (!item.validateWhenErrorExists(toValue(newValue) as V)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (muiProps?.onChange) {
+              muiProps.onChange(e, child);
             }
           }}
-          {...muiProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (muiProps?.onBlur) {
+              muiProps.onBlur(e);
+            }
+          }}
         >
           {item.options.map((o) => {
             return !item.isReadonly() ||
@@ -446,22 +471,27 @@ export const MxRadioBox = (props: MxRadioBoxProps) => {
             row
             value={item.value}
             name={"radio-group-" + item.key}
+            {...muiProps}
             onChange={(e, value: string) => {
               if (item.isReadonly()) return;
               item.setValue(value);
               if (!item.validateWhenErrorExists(value)) {
                 setRefresh(true);
               }
-            }}
-            onBlur={() => {
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
-              }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (muiProps?.onChange) {
+                muiProps.onChange(e, value);
               }
             }}
-            {...muiProps}
+            onBlur={(e) => {
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
+                }
+              }
+              if (muiProps?.onBlur) {
+                muiProps.onBlur(e);
+              }
+            }}
           >
             {item.options.map((o) => {
               const selected = o[item.optionValueKey] === item.value;
@@ -515,13 +545,16 @@ export const MxCheckBox = (props: MxCheckBoxProps) => {
                   className="checkbox-item"
                   value={item.value}
                   checked={item.value}
-                  onChange={(e, checked) => {
-                    if (item.isReadonly()) return;
-                    item.setValue(checked);
-                  }}
                   // Readonlyならグレーアウト、チェック済みはハイライト。イベントはCSSで無効化
                   disabled={item.isReadonly() && !item.value}
                   {...muiProps}
+                  onChange={(e, checked) => {
+                    if (item.isReadonly()) return;
+                    item.setValue(checked);
+                    if (muiProps?.onChange) {
+                      muiProps.onChange(e, checked);
+                    }
+                  }}
                 />
               }
               label={item.checkBoxText}
@@ -567,6 +600,11 @@ export const MxMultiCheckBox = (props: MxMultiCheckBoxProps) => {
                       key={value}
                       value={value}
                       checked={item.value?.includes(value)}
+                      // Readonlyならグレーアウト、チェック済みはハイライト。イベントはCSSで無効化
+                      disabled={
+                        item.isReadonly() && !item.value?.includes(value)
+                      }
+                      {...muiProps}
                       onChange={(e, checked) => {
                         if (item.isReadonly()) return;
                         let newValue: string[];
@@ -583,12 +621,10 @@ export const MxMultiCheckBox = (props: MxMultiCheckBoxProps) => {
                         if (!item.validateWhenErrorExists(newValue)) {
                           setRefresh(true);
                         }
+                        if (muiProps?.onChange) {
+                          muiProps.onChange(e, checked);
+                        }
                       }}
-                      // Readonlyならグレーアウト、チェック済みはハイライト。イベントはCSSで無効化
-                      disabled={
-                        item.isReadonly() && !item.value?.includes(value)
-                      }
-                      {...muiProps}
                     />
                   }
                   label={text}

--- a/src/framework/components/mui/MxCtrlAdvanced.tsx
+++ b/src/framework/components/mui/MxCtrlAdvanced.tsx
@@ -38,7 +38,8 @@ export const MxInputDate = (props: MxInputDateProps) => {
               className={getClassName(props, "fit-content")}
               value={valueDayjs}
               format={CsInputDateItem.dateDisplayFormat}
-              onChange={(value: dayjs.Dayjs | null) => {
+              {...muiProps}
+              onChange={(value: dayjs.Dayjs | null, context) => {
                 const newValue =
                   !value || !value.isValid()
                     ? undefined
@@ -47,8 +48,10 @@ export const MxInputDate = (props: MxInputDateProps) => {
                 if (!item.validateWhenErrorExists(newValue as string)) {
                   setRefresh(true);
                 }
+                if (muiProps?.onChange) {
+                  muiProps.onChange(value, context);
+                }
               }}
-              {...muiProps}
             />
           </LocalizationProvider>
         </div>
@@ -74,14 +77,17 @@ export const MxInputDateRange = (props: MxInputDateRangeProps) => {
     <MxEditCtrl
       mxProps={props}
       renderCtrl={(setRefresh) => (
-        <div style={{ display: "inline-block" }} onBlur={() => {
-          if (item.parentView?.validateTrigger !== "onBlur") {
-            return;
-          }
-          if (!item.validateDateRange()) {
-            setRefresh(true);
-          }
-        }}>
+        <div
+          style={{ display: "inline-block" }}
+          onBlur={() => {
+            if (item.parentView?.validateTrigger !== "onBlur") {
+              return;
+            }
+            if (!item.validateDateRange()) {
+              setRefresh(true);
+            }
+          }}
+        >
           <LocalizationProvider dateAdapter={AdapterDayjs}>
             <DatePicker
               className={getClassName(props, "fit-content")}
@@ -89,7 +95,8 @@ export const MxInputDateRange = (props: MxInputDateRangeProps) => {
               format={CsInputDateItem.dateDisplayFormat}
               maxDate={upperValueDayjs}
               readOnly={item.isReadonly()}
-              onChange={(value: dayjs.Dayjs | null) => {
+              {...muiPropsLower}
+              onChange={(value: dayjs.Dayjs | null, context) => {
                 const newValue =
                   !value || !value.isValid()
                     ? undefined
@@ -103,8 +110,10 @@ export const MxInputDateRange = (props: MxInputDateRangeProps) => {
                 if (!item.validateWhenErrorExists([newValue as string, newUpper as string])) {
                   setRefresh(true);
                 }
+                if (muiPropsLower?.onChange) {
+                  muiPropsLower.onChange(value, context);
+                }
               }}
-              {...muiPropsLower}
             />
             <div
               style={{
@@ -116,15 +125,16 @@ export const MxInputDateRange = (props: MxInputDateRangeProps) => {
               {" "}
               ～{" "}
             </div>
-            </LocalizationProvider>
-            <LocalizationProvider dateAdapter={AdapterDayjs}>
+          </LocalizationProvider>
+          <LocalizationProvider dateAdapter={AdapterDayjs}>
             <DatePicker
               className={getClassName(props, "fit-content")}
               value={upperValueDayjs}
               format={CsInputDateItem.dateDisplayFormat}
               minDate={lowerValueDayjs}
               readOnly={item.isReadonly()}
-              onChange={(value: dayjs.Dayjs | null) => {
+              {...muiPropsUpper}
+              onChange={(value: dayjs.Dayjs | null, context) => {
                 const newValue =
                   !value || !value.isValid()
                     ? undefined
@@ -138,8 +148,10 @@ export const MxInputDateRange = (props: MxInputDateRangeProps) => {
                 if (!item.validateWhenErrorExists([newLower as string, newValue as string])) {
                   setRefresh(true);
                 }
+                if (muiPropsUpper?.onChange) {
+                  muiPropsUpper.onChange(value, context);
+                }
               }}
-              {...muiPropsUpper}
             />
           </LocalizationProvider>
         </div>
@@ -168,6 +180,7 @@ export const MxInputNumberRange = (props: MxInputNumberRangeProps) => {
             inputProps={{
               readOnly: item.isReadonly(),
             }}
+            {...muiPropsLower}
             onChange={(
               e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
             ) => {
@@ -186,20 +199,28 @@ export const MxInputNumberRange = (props: MxInputNumberRangeProps) => {
                   setRefresh(true);
                 }
               }
+              if (muiPropsLower?.onChange) {
+                muiPropsLower.onChange(e);
+              }
             }}
-            onBlur={() => {
-              if (!item.lowerValue) return;
-              if (item.upperValue && item.upperValue < item.lowerValue) {
+            onBlur={(e) => {
+              if (
+                item.lowerValue &&
+                item.upperValue &&
+                item.lowerValue > item.upperValue
+              ) {
+                // 下限値が上限値より大きい場合、上限値を下限値に合わせる
                 item.setUpperValue(item.lowerValue);
               }
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
+                }
               }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (muiPropsLower?.onBlur) {
+                muiPropsLower.onBlur(e);
               }
             }}
-            {...muiPropsLower}
           />
           <div
             style={{
@@ -217,6 +238,7 @@ export const MxInputNumberRange = (props: MxInputNumberRangeProps) => {
             inputProps={{
               readOnly: item.isReadonly(),
             }}
+            {...muiPropsUpper}
             onChange={(
               e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
             ) => {
@@ -235,20 +257,28 @@ export const MxInputNumberRange = (props: MxInputNumberRangeProps) => {
                   setRefresh(true);
                 }
               }
+              if (muiPropsUpper?.onChange) {
+                muiPropsUpper.onChange(e);
+              }
             }}
-            onBlur={() => {
-              if (!item.upperValue) return;
-              if (item.lowerValue && item.lowerValue > item.upperValue) {
+            onBlur={(e) => {
+              if (
+                item.lowerValue &&
+                item.upperValue &&
+                item.upperValue < item.lowerValue
+              ) {
+                // 上限値が下限値より小さい場合、下限値を上限値に合わせる
                 item.setLowerValue(item.upperValue);
               }
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
+                }
               }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (muiPropsUpper?.onBlur) {
+                muiPropsUpper?.onBlur(e);
               }
             }}
-            {...muiPropsUpper}
           />
         </div>
       )}


### PR DESCRIPTION
## 概要
省力化コンポ部品のonChange, onBlurをカスタム利用可能にしました。

## 申し送り事項
- カスタム`onXxx`は、省力化コンポ部品内の`onXxx`の最後に実施するようにしています。
- readOnlyの早期returnによってカスタム`onChange`が実行されない場合がありますが、読み取り専用のときは`onChange`する必要がないので許容しています
- それ以外は、基本的に元onXxxの最後にカスタムonXxxが実行されるようになっています。
- 動作は確認済みです