### PR TITLE
コピー用資材の最新化

### DIFF
--- a/resource/antd/framework/components/antd/AxCtrl.tsx
+++ b/resource/antd/framework/components/antd/AxCtrl.tsx
@@ -58,6 +58,21 @@ export const AxLabel = (props: AxLabelProp) => {
   );
 };
 
+export interface AxLabelWithTagProps extends AxLabelProp {
+  required: boolean;
+  showRequiredTag?: "both" | "required" | "optional" | "none";
+}
+
+export const AxLabelWithTag = (props: AxLabelWithTagProps) => {
+  const showTag = props.showRequiredTag ?? "both";
+  return (
+    <AxLabel
+      label={getLabelWithTag(props.label, props.required, showTag)}
+      color={props.color}
+    />
+  );
+};
+
 export const getClassName = <T,>(
   props: AxProps<CsItem<T>>,
   add?: string[],
@@ -83,8 +98,17 @@ export const getLabel = <T,>(
   item: CsItem<T>,
   showRequiredTag?: "both" | "required" | "optional" | "none",
 ): ReactNode => {
+  const label = item.label;
   const required = item.validationRule?.required ?? false;
   const showTag = showRequiredTag ?? (item.parentView ? "both" : "none");
+  return getLabelWithTag(label, required, showTag);
+};
+
+export const getLabelWithTag = (
+  label: string | ReactNode,
+  required: boolean,
+  showTag: "both" | "required" | "optional" | "none",
+): ReactNode => {
   const requiredTag = () => {
     switch (showTag) {
       case "both":
@@ -101,7 +125,7 @@ export const getLabel = <T,>(
   };
   return (
     <span>
-      {item.label}
+      {label}
       {requiredTag()}
     </span>
   );
@@ -179,21 +203,26 @@ export const AxInputText = (props: AxInputTextProps) => {
           value={item.value}
           readOnly={item.isReadonly()}
           placeholder={item.placeholder}
+          {...antdProps}
           onChange={(e) => {
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (antdProps?.onChange) {
+              antdProps.onChange(e);
             }
           }}
-          {...antdProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (antdProps?.onBlur) {
+              antdProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // AxEditCtrl
@@ -215,6 +244,7 @@ export const AxInputNumber = (props: AxInputNumberProps) => {
           value={item.value}
           readOnly={item.isReadonly()}
           placeholder={item.placeholder}
+          {...antdProps}
           onChange={(value: ValueType | null) => {
             if (value !== null) {
               item.setValue(Number(value));
@@ -222,16 +252,20 @@ export const AxInputNumber = (props: AxInputNumberProps) => {
                 setRefresh(true);
               }
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (antdProps?.onChange) {
+              antdProps.onChange(value);
             }
           }}
-          {...antdProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (antdProps?.onBlur) {
+              antdProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // AxEditCtrl
@@ -253,21 +287,26 @@ export const AxInputPassword = (props: AxInputPasswordProps) => {
           value={item.value}
           readOnly={item.isReadonly()}
           placeholder={item.placeholder}
+          {...antdProps}
           onChange={(e) => {
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (antdProps?.onChange) {
+              antdProps.onChange(e);
             }
           }}
-          {...antdProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (antdProps?.onBlur) {
+              antdProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // AxEditCtrl
@@ -289,21 +328,26 @@ export const AxTextArea = (props: AxTextAreaProps) => {
           value={item.value}
           readOnly={item.isReadonly()}
           placeholder={item.placeholder}
+          {...antdProps}
           onChange={(e: ChangeEvent<HTMLTextAreaElement>) => {
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (antdProps?.onChange) {
+              antdProps.onChange(e);
             }
           }}
-          {...antdProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (antdProps?.onBlur) {
+              antdProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // AxEditCtrl
@@ -332,21 +376,26 @@ const AxSelectBoxCommon = <
           className={getClassName(props, ["fit-content"])}
           value={item.value}
           placeholder={item.placeholder}
+          {...antdProps}
           onChange={(value: V) => {
             item.setValue(value);
             if (!item.validateWhenErrorExists(value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (antdProps?.onChange) {
+              antdProps.onChange(value, item.options);
             }
           }}
-          {...antdProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (antdProps?.onBlur) {
+              antdProps.onBlur(e);
+            }
+          }}
         >
           {item.options.map((o) => {
             return !item.isReadonly() ||
@@ -396,22 +445,27 @@ export const AxRadioBox = (props: AxRadioBoxProps) => {
         <Radio.Group
           className={getClassName(props, ["fit-content"])}
           value={item.value}
+          {...antdProps}
           onChange={(e) => {
             if (item.isReadonly()) return;
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (antdProps?.onChange) {
+              antdProps.onChange(e);
             }
           }}
-          {...antdProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (antdProps?.onBlur) {
+              antdProps.onBlur(e);
+            }
+          }}
         >
           {item.options.map((o) => {
             return (
@@ -446,11 +500,14 @@ export const AxCheckBox = (props: AxCheckBoxProps) => {
           className={getClassName(props, ["fit-content", "checkbox"])}
           value={item.value}
           checked={item.value}
+          {...antdProps}
           onChange={(e) => {
             if (item.isReadonly()) return;
             item.setValue(e.target.checked);
+            if (antdProps?.onChange) {
+              antdProps.onChange(e);
+            }
           }}
-          {...antdProps}
         >
           {item.checkBoxText}
         </Checkbox>
@@ -489,6 +546,8 @@ export const AxMultiCheckBox = (props: AxMultiCheckBoxProps) => {
                 key={value}
                 value={value}
                 checked={item.value?.includes(value)}
+                disabled={item.isReadonly() && !item.value?.includes(value)}
+                {...antdProps}
                 onChange={(e) => {
                   if (item.isReadonly()) return;
                   let newValue: string[];
@@ -503,9 +562,10 @@ export const AxMultiCheckBox = (props: AxMultiCheckBoxProps) => {
                   if (!item.validateWhenErrorExists(newValue)) {
                     setRefresh(true);
                   }
+                  if (antdProps?.onChange) {
+                    antdProps.onChange(e);
+                  }
                 }}
-                disabled={item.isReadonly() && !item.value?.includes(value)}
-                {...antdProps}
               >
                 {text}
               </Checkbox>

--- a/resource/antd/framework/components/antd/AxCtrlAdvanced.tsx
+++ b/resource/antd/framework/components/antd/AxCtrlAdvanced.tsx
@@ -12,7 +12,7 @@ import {
   CsInputDateRangeItem,
   CsInputNumberRangeItem,
 } from "../../logics";
-import { AxProps, AxEditCtrl, getClassName } from "./AxCtrl";
+import { AxEditCtrl, AxProps, getClassName } from "./AxCtrl";
 
 const { RangePicker } = DatePicker;
 type RangePickerProps = GetProps<typeof DatePicker.RangePicker>;
@@ -41,6 +41,7 @@ export const AxInputDate = (props: AxInputDateProps) => {
             className={getClassName(props, ["fit-content"])}
             value={item.value ? dayjs(item.value) : undefined}
             format={item.displayFormat}
+            {...antdProps}
             onChange={(value: Dayjs, dateString: string | string[]) => {
               if (item.isReadonly()) return;
               const newValue = value?.format(item.valueFormat);
@@ -48,8 +49,10 @@ export const AxInputDate = (props: AxInputDateProps) => {
               if (!item.validateWhenErrorExists(newValue ?? "")) {
                 setRefresh(true);
               }
+              if (antdProps?.onChange) {
+                antdProps.onChange(value, newValue);
+              }
             }}
-            {...antdProps}
           />
         </div>
       )}
@@ -74,6 +77,14 @@ export const AxInputDateRange: React.FC<AxInputDateRangeProp> = (
         <RangePicker
           picker={item.isYearMonth() ? "month" : undefined}
           className={getClassName(props, ["fit-content"])}
+          allowClear={!item.validationRule.required}
+          value={[from, to] as [dayjs.Dayjs, dayjs.Dayjs]}
+          placeholder={[
+            item.lowerPlaceholder ?? "開始日を選択してください",
+            item.upperPlaceholder ?? "終了日を選択してください",
+          ]}
+          format={item.format}
+          {...antdProps}
           onCalendarChange={(dates, _, __) => {
             if (item.isReadonly()) {
               return;
@@ -99,15 +110,10 @@ export const AxInputDateRange: React.FC<AxInputDateRangeProp> = (
             ) {
               setRefresh(true);
             }
+            if (antdProps?.onCalendarChange) {
+              antdProps.onCalendarChange(dates, [newValue[0], newValue[1]], __);
+            }
           }}
-          allowClear={!item.validationRule.required}
-          value={[from, to] as [dayjs.Dayjs, dayjs.Dayjs]}
-          placeholder={[
-            item.lowerPlaceholder ?? "開始日を選択してください",
-            item.upperPlaceholder ?? "終了日を選択してください",
-          ]}
-          format={item.format}
-          {...antdProps}
           onBlur={(e, info) => {
             if (item.parentView?.validateTrigger === "onBlur") {
               // Calendar の変更を伴わないフォーカスアウトが行われた場合のバリデーション
@@ -149,6 +155,7 @@ export const AxInputNumberRange = (props: AxInputNumberRangeProps) => {
             className={getClassName(props, ["input-number"])}
             value={item.lowerValue}
             readOnly={item.isReadonly()}
+            {...antdPropsLower}
             onChange={(value) => {
               const newValue = value ? value : undefined;
               item.setLowerValue(newValue as number);
@@ -160,26 +167,35 @@ export const AxInputNumberRange = (props: AxInputNumberRangeProps) => {
               ) {
                 setRefresh(true);
               }
+              if (antdPropsLower?.onChange) {
+                antdPropsLower.onChange(value);
+              }
             }}
-            onBlur={() => {
-              if (!item.lowerValue) return;
-              if (item.upperValue && item.upperValue < item.lowerValue) {
+            onBlur={(e) => {
+              if (
+                item.lowerValue &&
+                item.upperValue &&
+                item.lowerValue > item.upperValue
+              ) {
+                // 下限値が上限値より大きい場合、上限値を下限値に合わせる
                 item.setUpperValue(item.lowerValue);
               }
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
+                }
               }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (antdPropsLower?.onBlur) {
+                antdPropsLower.onBlur(e);
               }
             }}
-            {...antdPropsLower}
           />
           <span> ～ </span>
           <InputNumber
             className={getClassName(props, ["input-number"])}
             value={item.upperValue}
             readOnly={item.isReadonly()}
+            {...antdPropsUpper}
             onChange={(value) => {
               const newValue = value ? value : undefined;
               item.setUpperValue(newValue as number);
@@ -191,20 +207,28 @@ export const AxInputNumberRange = (props: AxInputNumberRangeProps) => {
               ) {
                 setRefresh(true);
               }
+              if (antdPropsUpper?.onChange) {
+                antdPropsUpper.onChange(value);
+              }
             }}
-            onBlur={() => {
-              if (!item.upperValue) return;
-              if (item.lowerValue && item.lowerValue > item.upperValue) {
+            onBlur={(e) => {
+              if (
+                item.lowerValue &&
+                item.upperValue &&
+                item.upperValue < item.lowerValue
+              ) {
+                // 上限値が下限値より小さい場合、下限値を上限値に合わせる
                 item.setLowerValue(item.upperValue);
               }
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
+                }
               }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (antdPropsUpper?.onBlur) {
+                antdPropsUpper?.onBlur(e);
               }
             }}
-            {...antdPropsUpper}
           />
         </div>
       )}

--- a/resource/bootstrap/framework/components/bootstrap/BSxCtrl.tsx
+++ b/resource/bootstrap/framework/components/bootstrap/BSxCtrl.tsx
@@ -47,6 +47,21 @@ export const BSxLabel = (props: BSxLabelProp) => {
   );
 };
 
+export interface BSxLabelWithTagProps extends BSxLabelProp {
+  required: boolean;
+  showRequiredTag?: "both" | "required" | "optional" | "none";
+}
+
+export const BSxLabelWithTag = (props: BSxLabelWithTagProps) => {
+  const showTag = props.showRequiredTag ?? "both";
+  return (
+    <BSxLabel
+      label={getLabelWithTag(props.label, props.required, showTag)}
+      color={props.color}
+    />
+  );
+};
+
 export const getClassName = <T,>(
   props: BSxProps<CsItem<T>>,
   add?: string,
@@ -72,8 +87,17 @@ export const getLabel = <T,>(
   item: CsItem<T>,
   showRequiredTag?: "both" | "required" | "optional" | "none",
 ): ReactNode => {
+  const label = item.label;
   const required = item.validationRule?.required ?? false;
   const showTag = showRequiredTag ?? (item.parentView ? "both" : "none");
+  return getLabelWithTag(label, required, showTag);
+};
+
+export const getLabelWithTag = (
+  label: string | ReactNode,
+  required: boolean,
+  showTag: "both" | "required" | "optional" | "none",
+): ReactNode => {
   const requiredTag = () => {
     switch (showTag) {
       case "both":
@@ -102,7 +126,7 @@ export const getLabel = <T,>(
   };
   return (
     <span>
-      {item.label}
+      {label}
       {requiredTag()}
     </span>
   );
@@ -184,21 +208,26 @@ export const BSxInputText = (props: BSxInputTextProps) => {
           as="input"
           value={item.value}
           readOnly={item.isReadonly()}
+          {...bsProps}
           onChange={(e) => {
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (bsProps?.onChange) {
+              bsProps.onChange(e);
             }
           }}
-          {...bsProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (bsProps?.onBlur) {
+              bsProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // BSxEditCtrl
@@ -222,6 +251,7 @@ export const BSxInputNumber = (props: BSxInputNumberProps) => {
           type="number"
           value={item.value}
           readOnly={item.isReadonly()}
+          {...bsProps}
           onChange={(e) => {
             const newValue = e.target.value ? e.target.value : undefined;
             const newNumber = newValue ? Number(newValue) : undefined;
@@ -229,16 +259,20 @@ export const BSxInputNumber = (props: BSxInputNumberProps) => {
             if (!item.validateWhenErrorExists(newNumber as number)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (bsProps?.onChange) {
+              bsProps.onChange(e);
             }
           }}
-          {...bsProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (bsProps?.onBlur) {
+              bsProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // BSxEditCtrl
@@ -262,21 +296,26 @@ export const BSxInputPassword = (props: BSxInputPasswordProps) => {
           type="password"
           value={item.value}
           readOnly={item.isReadonly()}
+          {...bsProps}
           onChange={(e) => {
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (bsProps?.onChange) {
+              bsProps.onChange(e);
             }
           }}
-          {...bsProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (bsProps?.onBlur) {
+              bsProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // BSxEditCtrl
@@ -300,21 +339,26 @@ export const BSxTextArea = (props: BSxTextAreaProps) => {
           as="textarea"
           value={item.value}
           readOnly={item.isReadonly()}
+          {...bsProps}
           onChange={(e) => {
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (bsProps?.onChange) {
+              bsProps.onChange(e);
             }
           }}
-          {...bsProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (bsProps?.onBlur) {
+              bsProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // BSxEditCtrl
@@ -345,22 +389,27 @@ const BSxSelectBoxCommon = <
         <Form.Select
           className={getClassName(props, "fit-content")}
           value={item.value}
+          {...bsProps}
           onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
             const newValue = e.target.value;
             item.setValue(toValue(newValue));
             if (!item.validateWhenErrorExists(toValue(newValue) as V)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (bsProps?.onChange) {
+              bsProps.onChange(e);
             }
           }}
-          {...bsProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (bsProps?.onBlur) {
+              bsProps.onBlur(e);
+            }
+          }}
         >
           {(item.value === undefined || item.value === "") && (
             <option key="" value="" disabled={true} />
@@ -445,14 +494,17 @@ export const BSxRadioBox = (props: BSxRadioBoxProps) => {
                 value={value}
                 label={label}
                 disabled={item.isReadonly() && item.value !== value}
+                checked={item.value === value}
+                {...bsProps}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   item.setValue(e.target.value);
                   if (!item.validateWhenErrorExists(e.target.value)) {
                     setRefresh(true);
                   }
+                  if (bsProps?.onChange) {
+                    bsProps.onChange(e);
+                  }
                 }}
-                checked={item.value === value}
-                {...bsProps}
               />
             );
           })}
@@ -484,17 +536,19 @@ export const BSxCheckBox = (props: BSxCheckBoxProps) => {
               setRefresh(true);
             }
           }}
-          {...bsProps}
         >
           <Form.Check
             type="checkbox"
             label={item.checkBoxText}
             defaultChecked={item.isChecked()}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              item.setValue(e.target.checked);
-            }}
             disabled={item.isReadonly()}
             {...bsProps}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              item.setValue(e.target.checked);
+              if (bsProps?.onChange) {
+                bsProps.onChange(e);
+              }
+            }}
           />
         </Form.Group>
       )}
@@ -536,6 +590,8 @@ export const BSxMultiCheckBox = (props: BSxMultiCheckBoxProps) => {
                 type="checkbox"
                 defaultChecked={item.value?.includes(value)}
                 label={text}
+                disabled={item.isReadonly() && !item.value?.includes(value)}
+                {...bsProps}
                 onChange={(e) => {
                   if (item.isReadonly()) return;
                   let newValue: string[];
@@ -550,9 +606,10 @@ export const BSxMultiCheckBox = (props: BSxMultiCheckBoxProps) => {
                   if (!item.validateWhenErrorExists(newValue)) {
                     setRefresh(true);
                   }
+                  if (bsProps?.onChange) {
+                    bsProps.onChange(e);
+                  }
                 }}
-                disabled={item.isReadonly() && !item.value?.includes(value)}
-                {...bsProps}
               />
             );
           })}

--- a/resource/bootstrap/framework/components/bootstrap/BSxCtrlAdvanced.tsx
+++ b/resource/bootstrap/framework/components/bootstrap/BSxCtrlAdvanced.tsx
@@ -29,6 +29,7 @@ export const BSxInputDate = (props: BSxInputDateProps) => {
           className={getClassName(props, "fit-content")}
           type="date"
           value={displayValue}
+          {...bsProps}
           onChange={(e) => {
             if (item.isReadonly()) return;
             const newValue = e.target.value ? e.target.value : undefined;
@@ -39,16 +40,20 @@ export const BSxInputDate = (props: BSxInputDateProps) => {
             if (!item.validateWhenErrorExists(newValue)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (bsProps?.onChange) {
+              bsProps.onChange(e);
             }
           }}
-          {...bsProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (bsProps?.onBlur) {
+              bsProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // BSxEditCtrl
@@ -78,6 +83,7 @@ export const BSxInputDateRange = (props: BSxInputDateRangeProps) => {
             type="date"
             value={fromDisplayValue}
             readOnly={item.isReadonly()}
+            {...bsPropsLower}
             onChange={(e) => {
               const newValue = e.target.value ? e.target.value : undefined;
               const newDate = newValue
@@ -92,20 +98,28 @@ export const BSxInputDateRange = (props: BSxInputDateRangeProps) => {
               ) {
                 setRefresh(true);
               }
+              if (bsPropsLower?.onChange) {
+                bsPropsLower.onChange(e);
+              }
             }}
-            onBlur={() => {
-              if (!item.lowerValue) return;
-              if (item.upperValue && item.upperValue < item.lowerValue) {
+            onBlur={(e) => {
+              if (
+                item.lowerValue &&
+                item.upperValue &&
+                item.lowerValue > item.upperValue
+              ) {
+                // 下限値が上限値より大きい場合、上限値を下限値に合わせる
                 item.setUpperValue(item.lowerValue);
               }
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
+                }
               }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (bsPropsLower?.onBlur) {
+                bsPropsLower.onBlur(e);
               }
             }}
-            {...bsPropsLower}
           />
           <span
             style={{
@@ -122,6 +136,7 @@ export const BSxInputDateRange = (props: BSxInputDateRangeProps) => {
             type="date"
             value={toDisplayValue}
             readOnly={item.isReadonly()}
+            {...bsPropsUpper}
             onChange={(e) => {
               const newValue = e.target.value ? e.target.value : undefined;
               const newDate = newValue
@@ -136,20 +151,28 @@ export const BSxInputDateRange = (props: BSxInputDateRangeProps) => {
               ) {
                 setRefresh(true);
               }
+              if (bsPropsUpper?.onChange) {
+                bsPropsUpper.onChange(e);
+              }
             }}
-            onBlur={() => {
-              if (!item.upperValue) return;
-              if (item.lowerValue && item.lowerValue > item.upperValue) {
+            onBlur={(e) => {
+              if (
+                item.lowerValue &&
+                item.upperValue &&
+                item.upperValue < item.lowerValue
+              ) {
+                // 上限値が下限値より小さい場合、下限値を上限値に合わせる
                 item.setLowerValue(item.upperValue);
               }
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
+                }
               }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (bsPropsUpper?.onBlur) {
+                bsPropsUpper.onBlur(e);
               }
             }}
-            {...bsPropsUpper}
           />
         </div>
       )}
@@ -179,6 +202,7 @@ export const BSxInputNumberRange = (props: BSxInputNumberRangeProps) => {
             type="number"
             value={item.lowerValue}
             readOnly={item.isReadonly()}
+            {...bsPropsLower}
             onChange={(e) => {
               const newValue = e.target.value ? e.target.value : undefined;
               const newNumber = newValue ? Number(newValue) : undefined;
@@ -191,20 +215,28 @@ export const BSxInputNumberRange = (props: BSxInputNumberRangeProps) => {
               ) {
                 setRefresh(true);
               }
+              if (bsPropsLower?.onChange) {
+                bsPropsLower.onChange(e);
+              }
             }}
-            onBlur={() => {
-              if (!item.lowerValue) return;
-              if (item.upperValue && item.upperValue < item.lowerValue) {
+            onBlur={(e) => {
+              if (
+                item.lowerValue &&
+                item.upperValue &&
+                item.lowerValue > item.upperValue
+              ) {
+                // 下限値が上限値より大きい場合、上限値を下限値に合わせる
                 item.setUpperValue(item.lowerValue);
               }
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
+                }
               }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (bsPropsLower?.onBlur) {
+                bsPropsLower.onBlur(e);
               }
             }}
-            {...bsPropsLower}
           />
           <span
             style={{
@@ -221,6 +253,7 @@ export const BSxInputNumberRange = (props: BSxInputNumberRangeProps) => {
             type="number"
             value={item.upperValue}
             readOnly={item.isReadonly()}
+            {...bsPropsUpper}
             onChange={(e) => {
               const newValue = e.target.value ? e.target.value : undefined;
               const newNumber = newValue ? Number(newValue) : undefined;
@@ -233,20 +266,28 @@ export const BSxInputNumberRange = (props: BSxInputNumberRangeProps) => {
               ) {
                 setRefresh(true);
               }
+              if (bsPropsUpper?.onChange) {
+                bsPropsUpper.onChange(e);
+              }
             }}
-            onBlur={() => {
-              if (!item.upperValue) return;
-              if (item.lowerValue && item.lowerValue > item.upperValue) {
+            onBlur={(e) => {
+              if (
+                item.lowerValue &&
+                item.upperValue &&
+                item.upperValue < item.lowerValue
+              ) {
+                // 上限値が下限値より小さい場合、下限値を上限値に合わせる
                 item.setLowerValue(item.upperValue);
               }
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
+                }
               }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (bsPropsUpper?.onBlur) {
+                bsPropsUpper?.onBlur(e);
               }
             }}
-            {...bsPropsUpper}
           />
         </div>
       )}

--- a/resource/mui/framework/components/mui/MxCtrl.tsx
+++ b/resource/mui/framework/components/mui/MxCtrl.tsx
@@ -58,6 +58,21 @@ export const MxLabel = (props: MxLabelProp) => {
   );
 };
 
+export interface MxLabelWithTagProps extends MxLabelProp {
+  required: boolean;
+  showRequiredTag?: "both" | "required" | "optional" | "none";
+}
+
+export const MxLabelWithTag = (props: MxLabelWithTagProps) => {
+  const showTag = props.showRequiredTag ?? "both";
+  return (
+    <MxLabel
+      label={getLabelWithTag(props.label, props.required, showTag)}
+      color={props.color}
+    />
+  );
+};
+
 export const getClassName = <T,>(
   props: MxProps<CsItem<T>>,
   add?: string,
@@ -83,8 +98,17 @@ export const getLabel = <T,>(
   item: CsItem<T>,
   showRequiredTag?: "both" | "required" | "optional" | "none",
 ): ReactNode => {
+  const label = item.label;
   const required = item.validationRule?.required ?? false;
   const showTag = showRequiredTag ?? (item.parentView ? "both" : "none");
+  return getLabelWithTag(label, required, showTag);
+};
+
+export const getLabelWithTag = (
+  label: string | ReactNode,
+  required: boolean,
+  showTag: "both" | "required" | "optional" | "none",
+): ReactNode => {
   const requiredTag = () => {
     switch (showTag) {
       case "both":
@@ -121,7 +145,7 @@ export const getLabel = <T,>(
   };
   return (
     <span>
-      {item.label}
+      {label}
       {requiredTag()}
     </span>
   );
@@ -200,21 +224,26 @@ export const MxInputText = (props: MxInputTextProps) => {
           className={getClassName(props)}
           value={item.value}
           inputProps={{ readOnly: item.isReadonly() }}
-          onChange={(e: any) => {
+          {...muiProps}
+          onChange={(e) => {
             item.setValue(e.target.value);
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (muiProps?.onChange) {
+              muiProps.onChange(e);
             }
           }}
-          {...muiProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (muiProps?.onBlur) {
+              muiProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // MxEditCtrl
@@ -237,6 +266,7 @@ export const MxInputNumber = (props: MxInputNumberProps) => {
           inputProps={{
             readOnly: item.isReadonly(),
           }}
+          {...muiProps}
           onChange={(
             e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
           ) => {
@@ -250,16 +280,20 @@ export const MxInputNumber = (props: MxInputNumberProps) => {
                 setRefresh(true);
               }
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (muiProps?.onChange) {
+              muiProps.onChange(e);
             }
           }}
-          {...muiProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (muiProps?.onBlur) {
+              muiProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // MxEditCtrl
@@ -283,6 +317,7 @@ export const MxInputPassword = (props: MxInputPasswordProps) => {
             readOnly: item.isReadonly(),
           }}
           type="password"
+          {...muiProps}
           onChange={(
             e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
           ) => {
@@ -290,16 +325,20 @@ export const MxInputPassword = (props: MxInputPasswordProps) => {
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (muiProps?.onChange) {
+              muiProps.onChange(e);
             }
           }}
-          {...muiProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (muiProps?.onBlur) {
+              muiProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // MxEditCtrl
@@ -328,6 +367,7 @@ export const MxTextArea = (props: MxTextAreaProps) => {
           // multiline
           // minRows={4}
           variant="outlined"
+          {...muiProps}
           onChange={(
             e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
           ) => {
@@ -335,16 +375,20 @@ export const MxTextArea = (props: MxTextAreaProps) => {
             if (!item.validateWhenErrorExists(e.target.value)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (muiProps?.onChange) {
+              muiProps.onChange(e);
             }
           }}
-          {...muiProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (muiProps?.onBlur) {
+              muiProps.onBlur(e);
+            }
+          }}
         />
       )}
     /> // MxEditCtrl
@@ -373,22 +417,27 @@ const MxSelectBoxCommon = <
         <Select
           className={getClassName(props, "fit-content")}
           value={item.value}
-          onChange={(e: SelectChangeEvent<V>) => {
+          {...muiProps}
+          onChange={(e: SelectChangeEvent<V>, child: React.ReactNode) => {
             const newValue = e.target.value ? e.target.value.toString() : "";
             item.setValue(toValue(newValue));
             if (!item.validateWhenErrorExists(toValue(newValue) as V)) {
               setRefresh(true);
             }
-          }}
-          onBlur={() => {
-            if (item.parentView?.validateTrigger !== "onBlur") {
-              return;
-            }
-            if (!item.validate(item.value)) {
-              setRefresh(true);
+            if (muiProps?.onChange) {
+              muiProps.onChange(e, child);
             }
           }}
-          {...muiProps}
+          onBlur={(e) => {
+            if (item.parentView?.validateTrigger === "onBlur") {
+              if (!item.validate(item.value)) {
+                setRefresh(true);
+              }
+            }
+            if (muiProps?.onBlur) {
+              muiProps.onBlur(e);
+            }
+          }}
         >
           {item.options.map((o) => {
             return !item.isReadonly() ||
@@ -446,22 +495,27 @@ export const MxRadioBox = (props: MxRadioBoxProps) => {
             row
             value={item.value}
             name={"radio-group-" + item.key}
+            {...muiProps}
             onChange={(e, value: string) => {
               if (item.isReadonly()) return;
               item.setValue(value);
               if (!item.validateWhenErrorExists(value)) {
                 setRefresh(true);
               }
-            }}
-            onBlur={() => {
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
-              }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (muiProps?.onChange) {
+                muiProps.onChange(e, value);
               }
             }}
-            {...muiProps}
+            onBlur={(e) => {
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
+                }
+              }
+              if (muiProps?.onBlur) {
+                muiProps.onBlur(e);
+              }
+            }}
           >
             {item.options.map((o) => {
               const selected = o[item.optionValueKey] === item.value;
@@ -515,13 +569,16 @@ export const MxCheckBox = (props: MxCheckBoxProps) => {
                   className="checkbox-item"
                   value={item.value}
                   checked={item.value}
-                  onChange={(e, checked) => {
-                    if (item.isReadonly()) return;
-                    item.setValue(checked);
-                  }}
                   // Readonlyならグレーアウト、チェック済みはハイライト。イベントはCSSで無効化
                   disabled={item.isReadonly() && !item.value}
                   {...muiProps}
+                  onChange={(e, checked) => {
+                    if (item.isReadonly()) return;
+                    item.setValue(checked);
+                    if (muiProps?.onChange) {
+                      muiProps.onChange(e, checked);
+                    }
+                  }}
                 />
               }
               label={item.checkBoxText}
@@ -567,6 +624,11 @@ export const MxMultiCheckBox = (props: MxMultiCheckBoxProps) => {
                       key={value}
                       value={value}
                       checked={item.value?.includes(value)}
+                      // Readonlyならグレーアウト、チェック済みはハイライト。イベントはCSSで無効化
+                      disabled={
+                        item.isReadonly() && !item.value?.includes(value)
+                      }
+                      {...muiProps}
                       onChange={(e, checked) => {
                         if (item.isReadonly()) return;
                         let newValue: string[];
@@ -583,12 +645,10 @@ export const MxMultiCheckBox = (props: MxMultiCheckBoxProps) => {
                         if (!item.validateWhenErrorExists(newValue)) {
                           setRefresh(true);
                         }
+                        if (muiProps?.onChange) {
+                          muiProps.onChange(e, checked);
+                        }
                       }}
-                      // Readonlyならグレーアウト、チェック済みはハイライト。イベントはCSSで無効化
-                      disabled={
-                        item.isReadonly() && !item.value?.includes(value)
-                      }
-                      {...muiProps}
                     />
                   }
                   label={text}

--- a/resource/mui/framework/components/mui/MxCtrlAdvanced.tsx
+++ b/resource/mui/framework/components/mui/MxCtrlAdvanced.tsx
@@ -38,7 +38,8 @@ export const MxInputDate = (props: MxInputDateProps) => {
               className={getClassName(props, "fit-content")}
               value={valueDayjs}
               format={CsInputDateItem.dateDisplayFormat}
-              onChange={(value: dayjs.Dayjs | null) => {
+              {...muiProps}
+              onChange={(value: dayjs.Dayjs | null, context) => {
                 const newValue =
                   !value || !value.isValid()
                     ? undefined
@@ -47,8 +48,10 @@ export const MxInputDate = (props: MxInputDateProps) => {
                 if (!item.validateWhenErrorExists(newValue as string)) {
                   setRefresh(true);
                 }
+                if (muiProps?.onChange) {
+                  muiProps.onChange(value, context);
+                }
               }}
-              {...muiProps}
             />
           </LocalizationProvider>
         </div>
@@ -74,14 +77,17 @@ export const MxInputDateRange = (props: MxInputDateRangeProps) => {
     <MxEditCtrl
       mxProps={props}
       renderCtrl={(setRefresh) => (
-        <div style={{ display: "inline-block" }} onBlur={() => {
-          if (item.parentView?.validateTrigger !== "onBlur") {
-            return;
-          }
-          if (!item.validateDateRange()) {
-            setRefresh(true);
-          }
-        }}>
+        <div
+          style={{ display: "inline-block" }}
+          onBlur={() => {
+            if (item.parentView?.validateTrigger !== "onBlur") {
+              return;
+            }
+            if (!item.validateDateRange()) {
+              setRefresh(true);
+            }
+          }}
+        >
           <LocalizationProvider dateAdapter={AdapterDayjs}>
             <DatePicker
               className={getClassName(props, "fit-content")}
@@ -89,7 +95,8 @@ export const MxInputDateRange = (props: MxInputDateRangeProps) => {
               format={CsInputDateItem.dateDisplayFormat}
               maxDate={upperValueDayjs}
               readOnly={item.isReadonly()}
-              onChange={(value: dayjs.Dayjs | null) => {
+              {...muiPropsLower}
+              onChange={(value: dayjs.Dayjs | null, context) => {
                 const newValue =
                   !value || !value.isValid()
                     ? undefined
@@ -103,8 +110,10 @@ export const MxInputDateRange = (props: MxInputDateRangeProps) => {
                 if (!item.validateWhenErrorExists([newValue as string, newUpper as string])) {
                   setRefresh(true);
                 }
+                if (muiPropsLower?.onChange) {
+                  muiPropsLower.onChange(value, context);
+                }
               }}
-              {...muiPropsLower}
             />
             <div
               style={{
@@ -116,15 +125,16 @@ export const MxInputDateRange = (props: MxInputDateRangeProps) => {
               {" "}
               ～{" "}
             </div>
-            </LocalizationProvider>
-            <LocalizationProvider dateAdapter={AdapterDayjs}>
+          </LocalizationProvider>
+          <LocalizationProvider dateAdapter={AdapterDayjs}>
             <DatePicker
               className={getClassName(props, "fit-content")}
               value={upperValueDayjs}
               format={CsInputDateItem.dateDisplayFormat}
               minDate={lowerValueDayjs}
               readOnly={item.isReadonly()}
-              onChange={(value: dayjs.Dayjs | null) => {
+              {...muiPropsUpper}
+              onChange={(value: dayjs.Dayjs | null, context) => {
                 const newValue =
                   !value || !value.isValid()
                     ? undefined
@@ -138,8 +148,10 @@ export const MxInputDateRange = (props: MxInputDateRangeProps) => {
                 if (!item.validateWhenErrorExists([newLower as string, newValue as string])) {
                   setRefresh(true);
                 }
+                if (muiPropsUpper?.onChange) {
+                  muiPropsUpper.onChange(value, context);
+                }
               }}
-              {...muiPropsUpper}
             />
           </LocalizationProvider>
         </div>
@@ -168,6 +180,7 @@ export const MxInputNumberRange = (props: MxInputNumberRangeProps) => {
             inputProps={{
               readOnly: item.isReadonly(),
             }}
+            {...muiPropsLower}
             onChange={(
               e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
             ) => {
@@ -186,20 +199,28 @@ export const MxInputNumberRange = (props: MxInputNumberRangeProps) => {
                   setRefresh(true);
                 }
               }
+              if (muiPropsLower?.onChange) {
+                muiPropsLower.onChange(e);
+              }
             }}
-            onBlur={() => {
-              if (!item.lowerValue) return;
-              if (item.upperValue && item.upperValue < item.lowerValue) {
+            onBlur={(e) => {
+              if (
+                item.lowerValue &&
+                item.upperValue &&
+                item.lowerValue > item.upperValue
+              ) {
+                // 下限値が上限値より大きい場合、上限値を下限値に合わせる
                 item.setUpperValue(item.lowerValue);
               }
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
+                }
               }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (muiPropsLower?.onBlur) {
+                muiPropsLower.onBlur(e);
               }
             }}
-            {...muiPropsLower}
           />
           <div
             style={{
@@ -217,6 +238,7 @@ export const MxInputNumberRange = (props: MxInputNumberRangeProps) => {
             inputProps={{
               readOnly: item.isReadonly(),
             }}
+            {...muiPropsUpper}
             onChange={(
               e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
             ) => {
@@ -235,20 +257,28 @@ export const MxInputNumberRange = (props: MxInputNumberRangeProps) => {
                   setRefresh(true);
                 }
               }
+              if (muiPropsUpper?.onChange) {
+                muiPropsUpper.onChange(e);
+              }
             }}
-            onBlur={() => {
-              if (!item.upperValue) return;
-              if (item.lowerValue && item.lowerValue > item.upperValue) {
+            onBlur={(e) => {
+              if (
+                item.lowerValue &&
+                item.upperValue &&
+                item.upperValue < item.lowerValue
+              ) {
+                // 上限値が下限値より小さい場合、下限値を上限値に合わせる
                 item.setLowerValue(item.upperValue);
               }
-              if (item.parentView?.validateTrigger !== "onBlur") {
-                return;
+              if (item.parentView?.validateTrigger === "onBlur") {
+                if (!item.validate(item.value)) {
+                  setRefresh(true);
+                }
               }
-              if (!item.validate(item.value)) {
-                setRefresh(true);
+              if (muiPropsUpper?.onBlur) {
+                muiPropsUpper?.onBlur(e);
               }
             }}
-            {...muiPropsUpper}
           />
         </div>
       )}

--- a/resource/stories-antd/framework/stories/antd/AxLabelWithTag.stories.tsx
+++ b/resource/stories-antd/framework/stories/antd/AxLabelWithTag.stories.tsx
@@ -1,0 +1,59 @@
+import {
+  AxLabelWithTag,
+  AxLabelWithTagProps,
+} from "@/framework/components/antd";
+import { Meta, StoryObj } from "@storybook/react";
+
+/**
+ * タグ付きのラベルを単体で表示するためのコンポーネントです。
+ */
+const meta: Meta<typeof AxLabelWithTag> = {
+  title: "ant Design/AxLabelWithTag",
+  component: AxLabelWithTag,
+  tags: ["autodocs"],
+  argTypes: {
+    label: {
+      control: "text",
+      description: `ラベル名を指定します。`,
+      table: {
+        type: { summary: "string | ReactNode" },
+      },
+    },
+    required: {
+      control: "boolean",
+      description:
+        "必須タグ/任意タグのどちらを表示するかを指定します。`true`の場合は必須タグ、`false`の場合は任意タグが表示されます。",
+    },
+    showRequiredTag: {
+      control: "radio",
+      description:
+        "必須タグ/任意タグの表示有無を指定します。`required`の場合は必須タグのみ、" +
+        "`optional`の場合は任意タグのみ表示されます。`both`の場合は必須と任意両方のタグが表示されます。" +
+        "`none`の場合はタグが表示されません。<br>" +
+        "必須か任意かは、`required`propsの値が`true`であるかに依存します。",
+      table: {
+        defaultValue: { summary: "both" },
+      },
+    },
+    color: {
+      control: "color",
+      description: `ラベルの文字色を指定します。`,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const defaultArgs: Partial<AxLabelWithTagProps> = {
+  label: "ラベル",
+  required: true,
+  showRequiredTag: "both",
+};
+
+export const AxLabelWithTagStory: Story = {
+  args: defaultArgs,
+  render: function Render(args: AxLabelWithTagProps) {
+    return <AxLabelWithTag {...args} />;
+  },
+};

--- a/resource/stories-antd/framework/stories/antd/AxMutateButton.stories.tsx
+++ b/resource/stories-antd/framework/stories/antd/AxMutateButton.stories.tsx
@@ -98,7 +98,7 @@ const meta: Meta<typeof AxMutateButton> = {
     },
     onAfterApiCallSuccess: {
       control: false,
-      description: "API呼び出し成功後に実行する処理を指定します。",
+      description: "API呼び出し成功後(レスポンスのHTTPステータスコード200系の場合)に実行する処理を指定します。",
       table: {
         type: {
           summary:
@@ -108,7 +108,7 @@ const meta: Meta<typeof AxMutateButton> = {
     },
     onAfterApiCallError: {
       control: false,
-      description: "API呼び出し失敗後に実行する処理を指定します。",
+      description: "API呼び出し失敗後(レスポンスのHTTPステータスコード400系/500系の場合)に実行する処理を指定します。",
       table: {
         type: {
           summary:

--- a/resource/stories-antd/framework/stories/antd/AxQueryButton.stories.tsx
+++ b/resource/stories-antd/framework/stories/antd/AxQueryButton.stories.tsx
@@ -98,7 +98,7 @@ const meta: Meta<typeof AxQueryButton> = {
     },
     onAfterApiCallSuccess: {
       control: false,
-      description: "API呼び出し成功後に実行する処理を指定します。",
+      description: "API呼び出し成功後(レスポンスのHTTPステータスコード200系の場合)に実行する処理を指定します。",
       table: {
         type: {
           summary:
@@ -108,7 +108,7 @@ const meta: Meta<typeof AxQueryButton> = {
     },
     onAfterApiCallError: {
       control: false,
-      description: "API呼び出し失敗後に実行する処理を指定します。",
+      description: "API呼び出し失敗後(レスポンスのHTTPステータスコード400系/500系の場合)に実行する処理を指定します。",
       table: {
         type: {
           summary:

--- a/resource/stories-bootstrap/framework/stories/bootstrap/BSxLabelWithTag.stories.tsx
+++ b/resource/stories-bootstrap/framework/stories/bootstrap/BSxLabelWithTag.stories.tsx
@@ -1,0 +1,59 @@
+import {
+  BSxLabelWithTag,
+  BSxLabelWithTagProps,
+} from "@/framework/components/bootstrap";
+import { Meta, StoryObj } from "@storybook/react";
+
+/**
+ * タグ付きのラベルを単体で表示するためのコンポーネントです。
+ */
+const meta: Meta<typeof BSxLabelWithTag> = {
+  title: "Bootstrap/BSxLabelWithTag",
+  component: BSxLabelWithTag,
+  tags: ["autodocs"],
+  argTypes: {
+    label: {
+      control: "text",
+      description: `ラベル名を指定します。`,
+      table: {
+        type: { summary: "string | ReactNode" },
+      },
+    },
+    required: {
+      control: "boolean",
+      description:
+        "必須タグ/任意タグのどちらを表示するかを指定します。`true`の場合は必須タグ、`false`の場合は任意タグが表示されます。",
+    },
+    showRequiredTag: {
+      control: "radio",
+      description:
+        "必須タグ/任意タグの表示有無を指定します。`required`の場合は必須タグのみ、" +
+        "`optional`の場合は任意タグのみ表示されます。`both`の場合は必須と任意両方のタグが表示されます。" +
+        "`none`の場合はタグが表示されません。<br>" +
+        "必須か任意かは、`required`propsの値が`true`であるかに依存します。",
+      table: {
+        defaultValue: { summary: "both" },
+      },
+    },
+    color: {
+      control: "color",
+      description: `ラベルの文字色を指定します。`,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const defaultArgs: Partial<BSxLabelWithTagProps> = {
+  label: "ラベル",
+  required: true,
+  showRequiredTag: "both",
+};
+
+export const BSxLabelWithTagStory: Story = {
+  args: defaultArgs,
+  render: function Render(args: BSxLabelWithTagProps) {
+    return <BSxLabelWithTag {...args} />;
+  },
+};

--- a/resource/stories-bootstrap/framework/stories/bootstrap/BSxMutateButton.stories.tsx
+++ b/resource/stories-bootstrap/framework/stories/bootstrap/BSxMutateButton.stories.tsx
@@ -116,7 +116,7 @@ const meta: Meta<typeof BSxMutateButton> = {
     },
     onAfterApiCallSuccess: {
       control: false,
-      description: "API呼び出し成功後に実行する処理を指定します。",
+      description: "API呼び出し成功後(レスポンスのHTTPステータスコード200系の場合)に実行する処理を指定します。",
       table: {
         type: {
           summary:
@@ -126,7 +126,7 @@ const meta: Meta<typeof BSxMutateButton> = {
     },
     onAfterApiCallError: {
       control: false,
-      description: "API呼び出し失敗後に実行する処理を指定します。",
+      description: "API呼び出し失敗後(レスポンスのHTTPステータスコード400系/500系の場合)に実行する処理を指定します。",
       table: {
         type: {
           summary:

--- a/resource/stories-bootstrap/framework/stories/bootstrap/BSxQueryButton.stories.tsx
+++ b/resource/stories-bootstrap/framework/stories/bootstrap/BSxQueryButton.stories.tsx
@@ -116,7 +116,7 @@ const meta: Meta<typeof BSxQueryButton> = {
     },
     onAfterApiCallSuccess: {
       control: false,
-      description: "API呼び出し成功後に実行する処理を指定します。",
+      description: "API呼び出し成功後(レスポンスのHTTPステータスコード200系の場合)に実行する処理を指定します。",
       table: {
         type: {
           summary:
@@ -126,7 +126,7 @@ const meta: Meta<typeof BSxQueryButton> = {
     },
     onAfterApiCallError: {
       control: false,
-      description: "API呼び出し失敗後に実行する処理を指定します。",
+      description: "API呼び出し失敗後(レスポンスのHTTPステータスコード400系/500系の場合)に実行する処理を指定します。",
       table: {
         type: {
           summary:

--- a/resource/stories-mui/framework/stories/mui/MxLabelWithTag.stories.tsx
+++ b/resource/stories-mui/framework/stories/mui/MxLabelWithTag.stories.tsx
@@ -1,0 +1,59 @@
+import {
+  MxLabelWithTag,
+  MxLabelWithTagProps,
+} from "@/framework/components/mui";
+import { Meta, StoryObj } from "@storybook/react";
+
+/**
+ * タグ付きのラベルを単体で表示するためのコンポーネントです。
+ */
+const meta: Meta<typeof MxLabelWithTag> = {
+  title: "Material UI/MxLabelWithTag",
+  component: MxLabelWithTag,
+  tags: ["autodocs"],
+  argTypes: {
+    label: {
+      control: "text",
+      description: `ラベル名を指定します。`,
+      table: {
+        type: { summary: "string | ReactNode" },
+      },
+    },
+    required: {
+      control: "boolean",
+      description:
+        "必須タグ/任意タグのどちらを表示するかを指定します。`true`の場合は必須タグ、`false`の場合は任意タグが表示されます。",
+    },
+    showRequiredTag: {
+      control: "radio",
+      description:
+        "必須タグ/任意タグの表示有無を指定します。`required`の場合は必須タグのみ、" +
+        "`optional`の場合は任意タグのみ表示されます。`both`の場合は必須と任意両方のタグが表示されます。" +
+        "`none`の場合はタグが表示されません。<br>" +
+        "必須か任意かは、`required`propsの値が`true`であるかに依存します。",
+      table: {
+        defaultValue: { summary: "both" },
+      },
+    },
+    color: {
+      control: "color",
+      description: `ラベルの文字色を指定します。`,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const defaultArgs: Partial<MxLabelWithTagProps> = {
+  label: "ラベル",
+  required: true,
+  showRequiredTag: "both",
+};
+
+export const MxLabelWithTagStory: Story = {
+  args: defaultArgs,
+  render: function Render(args: MxLabelWithTagProps) {
+    return <MxLabelWithTag {...args} />;
+  },
+};

--- a/resource/stories-mui/framework/stories/mui/MxMutateButton.stories.tsx
+++ b/resource/stories-mui/framework/stories/mui/MxMutateButton.stories.tsx
@@ -98,7 +98,7 @@ const meta: Meta<typeof MxMutateButton> = {
     },
     onAfterApiCallSuccess: {
       control: false,
-      description: "API呼び出し成功後に実行する処理を指定します。",
+      description: "API呼び出し成功後(レスポンスのHTTPステータスコード200系の場合)に実行する処理を指定します。",
       table: {
         type: {
           summary:
@@ -108,7 +108,7 @@ const meta: Meta<typeof MxMutateButton> = {
     },
     onAfterApiCallError: {
       control: false,
-      description: "API呼び出し失敗後に実行する処理を指定します。",
+      description: "API呼び出し失敗後(レスポンスのHTTPステータスコード400系/500系の場合)に実行する処理を指定します。",
       table: {
         type: {
           summary:

--- a/resource/stories-mui/framework/stories/mui/MxQueryButton.stories.tsx
+++ b/resource/stories-mui/framework/stories/mui/MxQueryButton.stories.tsx
@@ -98,7 +98,7 @@ const meta: Meta<typeof MxQueryButton> = {
     },
     onAfterApiCallSuccess: {
       control: false,
-      description: "API呼び出し成功後に実行する処理を指定します。",
+      description: "API呼び出し成功後(レスポンスのHTTPステータスコード200系の場合)に実行する処理を指定します。",
       table: {
         type: {
           summary:
@@ -108,7 +108,7 @@ const meta: Meta<typeof MxQueryButton> = {
     },
     onAfterApiCallError: {
       control: false,
-      description: "API呼び出し失敗後に実行する処理を指定します。",
+      description: "API呼び出し失敗後(レスポンスのHTTPステータスコード400系/500系の場合)に実行する処理を指定します。",
       table: {
         type: {
           summary:

--- a/resource/yup/framework/logics/yup/CsYupValidationEvent.ts
+++ b/resource/yup/framework/logics/yup/CsYupValidationEvent.ts
@@ -85,24 +85,29 @@ const createStringConstraint = (
       ? yup.string().required(item.label + "は必須です。値を設定してください")
       : yup.string().optional();
     const min = sRule.min ?? (sRule.required ? 1 : undefined);
-    if (min !== undefined) {
-      const message =
-        min === 1 && sRule.required
-          ? item.label + "は必須です。値を設定してください"
-          : item.label +
-            "が短すぎます。 " +
-            sRule.min +
-            "文字より長い文字列を入力してください";
-      sy = sy.min(min, message);
-    }
-    if (sRule.max !== undefined) {
-      sy = sy.max(
-        sRule.max,
-        item.label +
-          "が長すぎます。 " +
-          sRule.max +
-          "文字より短い文字列を入力してください",
-      );
+    if (!!min && min === sRule.max) {
+      sy = sy.min(min, item.label + "は" + min + "文字で入力してください");
+      sy = sy.max(min, item.label + "は" + min + "文字で入力してください");
+    } else {
+      if (min !== undefined) {
+        const message =
+          min === 1 && sRule.required
+            ? item.label + "は必須です。値を設定してください"
+            : item.label +
+              "が短すぎます。 " +
+              sRule.min +
+              "文字以上の文字列を入力してください";
+        sy = sy.min(min, message);
+      }
+      if (sRule.max !== undefined) {
+        sy = sy.max(
+          sRule.max,
+          item.label +
+            "が長すぎます。 " +
+            sRule.max +
+            "文字以下の文字列を入力してください",
+        );
+      }
     }
     if (sRule.email) {
       sy = sy.email(
@@ -123,23 +128,34 @@ const createNumberConstraint = (
     let ny = nRule.required
       ? yup.number().required(item.label + "は必須です。値を設定してください")
       : yup.number().optional();
-    if (nRule.min !== undefined) {
+    if (!!nRule.min && nRule.min === nRule.max) {
       ny = ny.min(
         nRule.min,
-        item.label +
-          "が小さすぎます。 " +
-          nRule.min +
-          "より大きい数を入力してください",
+        item.label + "には" + nRule.min + "を入力してください",
       );
-    }
-    if (nRule.max !== undefined) {
       ny = ny.max(
-        nRule.max,
-        item.label +
-          "が大きすぎます。 " +
-          nRule.max +
-          "より小さい数を入力してください",
+        nRule.min,
+        item.label + "には" + nRule.min + "を入力してください",
       );
+    } else {
+      if (nRule.min !== undefined) {
+        ny = ny.min(
+          nRule.min,
+          item.label +
+            "が小さすぎます。 " +
+            nRule.min +
+            "以上の数を入力してください",
+        );
+      }
+      if (nRule.max !== undefined) {
+        ny = ny.max(
+          nRule.max,
+          item.label +
+            "が大きすぎます。 " +
+            nRule.max +
+            "以下の数を入力してください",
+        );
+      }
     }
     validationMap.set(key, ny);
   }
@@ -172,23 +188,34 @@ const createNumberArrayConstraint = (
     let ny = nRule.required
       ? yup.number().required(item.label + "は必須です。値を設定してください")
       : yup.number().optional();
-    if (nRule.min) {
+    if (!!nRule.min && nRule.min === nRule.max) {
       ny = ny.min(
         nRule.min,
-        item.label +
-          "が小さすぎます。 " +
-          nRule.min +
-          "より大きい数を入力してください",
+        item.label + "には" + nRule.min + "を入力してください",
       );
-    }
-    if (nRule.max) {
       ny = ny.max(
-        nRule.max,
-        item.label +
-          "が大きすぎます。 " +
-          nRule.max +
-          "より小さい数を入力してください",
+        nRule.min,
+        item.label + "には" + nRule.min + "を入力してください",
       );
+    } else {
+      if (nRule.min) {
+        ny = ny.min(
+          nRule.min,
+          item.label +
+            "が小さすぎます。 " +
+            nRule.min +
+            "以上の数を入力してください",
+        );
+      }
+      if (nRule.max) {
+        ny = ny.max(
+          nRule.max,
+          item.label +
+            "が大きすぎます。 " +
+            nRule.max +
+            "以下の数を入力してください",
+        );
+      }
     }
     const nay = yup.array(ny);
     validationMap.set(key, nay);

--- a/resource/zod/framework/logics/zod/CsZodValidationEvent.ts
+++ b/resource/zod/framework/logics/zod/CsZodValidationEvent.ts
@@ -90,24 +90,29 @@ const createStringConstraint = (
         })
       : z.string();
     const min = sRule.min ?? (sRule.required ? 1 : undefined);
-    if (min !== undefined) {
-      const message =
-        min === 1 && sRule.required
-          ? item.label + "は必須です。値を設定してください"
-          : item.label +
-            "が短すぎます。 " +
-            sRule.min +
-            "文字より長い文字列を入力してください";
-      sz = sz.min(min, message);
-    }
-    if (sRule.max !== undefined) {
-      sz = sz.max(
-        sRule.max,
-        item.label +
-          "が長すぎます。 " +
-          sRule.max +
-          "文字より短い文字列を入力してください",
-      );
+    if (!!min && min === sRule.max) {
+      sz = sz.min(min, item.label + "は" + min + "文字で入力してください");
+      sz = sz.max(min, item.label + "は" + min + "文字で入力してください");
+    } else {
+      if (min !== undefined) {
+        const message =
+          min === 1 && sRule.required
+            ? item.label + "は必須です。値を設定してください"
+            : item.label +
+              "が短すぎます。 " +
+              sRule.min +
+              "文字以上の文字列を入力してください";
+        sz = sz.min(min, message);
+      }
+      if (sRule.max !== undefined) {
+        sz = sz.max(
+          sRule.max,
+          item.label +
+            "が長すぎます。 " +
+            sRule.max +
+            "文字以下の文字列を入力してください",
+        );
+      }
     }
     if (sRule.email) {
       sz = sz.email(
@@ -134,23 +139,34 @@ const createNumberConstraint = (
           required_error: item.label + "は必須です。値を設定してください",
         })
       : z.number();
-    if (nRule.min !== undefined) {
+    if (!!nRule.min && nRule.min === nRule.max) {
       nz = nz.min(
         nRule.min,
-        item.label +
-          "が小さすぎます。 " +
-          nRule.min +
-          "より大きい数を入力してください",
+        item.label + "には" + nRule.min + "を入力してください",
       );
-    }
-    if (nRule.max !== undefined) {
       nz = nz.max(
-        nRule.max,
-        item.label +
-          "が大きすぎます。 " +
-          nRule.max +
-          "より小さい数を入力してください",
+        nRule.min,
+        item.label + "には" + nRule.min + "を入力してください",
       );
+    } else {
+      if (nRule.min !== undefined) {
+        nz = nz.min(
+          nRule.min,
+          item.label +
+            "が小さすぎます。 " +
+            nRule.min +
+            "以上の数を入力してください",
+        );
+      }
+      if (nRule.max !== undefined) {
+        nz = nz.max(
+          nRule.max,
+          item.label +
+            "が大きすぎます。 " +
+            nRule.max +
+            "以下の数を入力してください",
+        );
+      }
     }
     let onz;
     if (!nRule.required) {
@@ -188,22 +204,33 @@ const createNumberArrayConstraint = (
           required_error: item.label + "は必須です。値を設定してください",
         })
       : z.number();
-    if (nRule.min)
+    if (!!nRule.min && nRule.min === nRule.max) {
       nz = nz.min(
         nRule.min,
-        item.label +
-          "が小さすぎます。 " +
-          nRule.min +
-          "より大きい数を入力してください",
+        item.label + "には" + nRule.min + "を入力してください",
       );
-    if (nRule.max)
       nz = nz.max(
-        nRule.max,
-        item.label +
-          "が大きすぎます。 " +
-          nRule.max +
-          "より小さい数を入力してください",
+        nRule.min,
+        item.label + "には" + nRule.min + "を入力してください",
       );
+    } else {
+      if (nRule.min)
+        nz = nz.min(
+          nRule.min,
+          item.label +
+            "が小さすぎます。 " +
+            nRule.min +
+            "以上の数を入力してください",
+        );
+      if (nRule.max)
+        nz = nz.max(
+          nRule.max,
+          item.label +
+            "が大きすぎます。 " +
+            nRule.max +
+            "以下の数を入力してください",
+        );
+    }
     let onz;
     if (!nRule.required) onz = nz.optional();
     const naz = z.array(onz ?? nz);


### PR DESCRIPTION
## 概要
src/framework配下に行った修正を、コピー用の資材にも反映しました。

## 申し送り事項
- FB作業全体で修正したのは18ファイルで、うち自動テストが1ファイル含まれるため、コピー資材への反映対象は17ファイル 
![image](https://github.com/user-attachments/assets/a6f5e637-d341-451f-86a2-c5539f8dc66f)

- Ant Design の場合でコピー機能を試し、デモ画面/Storybookが正常に（修正も反映された状態で）起動されることを確認済み
- 自動テストは全てPASSを確認済み